### PR TITLE
fix: Make sure output is copied to a buffer after a function call

### DIFF
--- a/extism.go
+++ b/extism.go
@@ -384,7 +384,12 @@ func (plugin *Plugin) GetOutput() ([]byte, error) {
 		return []byte{}, err
 	}
 	mem, _ := plugin.Memory().Read(uint32(outputOffs[0]), uint32(outputLen[0]))
-	return mem, nil
+
+	// Make sure output is copied, because `Read` returns a write-through view
+	buffer := make([]byte, len(mem))
+	copy(buffer, mem)
+
+	return buffer, nil
 }
 
 // Memory returns the plugin's WebAssembly memory interface.

--- a/extism_test.go
+++ b/extism_test.go
@@ -499,6 +499,29 @@ func TestCountVowels(t *testing.T) {
 	}
 }
 
+func TestMultipleCallsOutput(t *testing.T) {
+	manifest := manifest("count_vowels.wasm")
+
+	if plugin, ok := plugin(t, manifest); ok {
+		defer plugin.Close()
+
+		exit, output1, err := plugin.Call("count_vowels", []byte("aaa"))
+
+		if !assertCall(t, err, exit) {
+			return
+		}
+
+		exit, output2, err := plugin.Call("count_vowels", []byte("bbb"))
+
+		if !assertCall(t, err, exit) {
+			return
+		}
+
+		assert.Equal(t, `{"count": 3}`, string(output1))
+		assert.Equal(t, `{"count": 0}`, string(output2))
+	}
+}
+
 func TestHelloHaskell(t *testing.T) {
 	var buf bytes.Buffer
 	log.SetOutput(&buf)


### PR DESCRIPTION
This fixes https://github.com/extism/go-sdk/issues/5#issuecomment-1666736435

From Wazero's docs about `Memory.Read()`
> 	This returns a view of the underlying memory, not a copy. This means any
	writes to the slice returned are visible to Wasm, and any updates from
	 Wasm are visible reading the returned slice.