### PR TITLE
refactor: Simplify runtime initialization

### DIFF
--- a/extism.go
+++ b/extism.go
@@ -342,11 +342,6 @@ func NewPlugin(
 				logLevel:       logLevel}
 
 			p.guestRuntime = guestRuntime(p)
-
-			if p.guestRuntime.InitOnce != nil {
-				p.guestRuntime.InitOnce()
-			}
-
 			return p, nil
 		}
 

--- a/extism.go
+++ b/extism.go
@@ -445,11 +445,12 @@ func (plugin *Plugin) Call(name string, data []byte) (uint32, []byte, error) {
 		return 1, []byte{}, errors.New(fmt.Sprintf("Function %s has %v results, expected 0 or 1", name, n))
 	}
 
-	if !isStart && plugin.guestRuntime.Init != nil {
+	if plugin.guestRuntime.Init != nil && (isStart || !plugin.guestRuntime.initialized) {
 		err := plugin.guestRuntime.Init()
 		if err != nil {
 			return 1, []byte{}, errors.New(fmt.Sprintf("failed to initialize runtime: %v", err))
 		}
+		plugin.guestRuntime.initialized = true
 	}
 
 	plugin.Logf(Debug, "Calling function : %v", name)
@@ -466,13 +467,6 @@ func (plugin *Plugin) Call(name string, data []byte) (uint32, []byte, error) {
 
 		if len(res) == 0 {
 			res = []uint64{api.EncodeU32(exitCode)}
-		}
-	}
-
-	if !isStart && plugin.guestRuntime.Cleanup != nil {
-		err := plugin.guestRuntime.Cleanup()
-		if err != nil {
-			return 1, []byte{}, errors.New(fmt.Sprintf("failed to cleanup runtime: %v", err))
 		}
 	}
 

--- a/extism.go
+++ b/extism.go
@@ -435,8 +435,6 @@ func (plugin *Plugin) Call(name string, data []byte) (uint32, []byte, error) {
 		return 1, []byte{}, err
 	}
 
-	isStart := name == "_start"
-
 	var f = plugin.Main.ExportedFunction(name)
 
 	if f == nil {
@@ -445,7 +443,8 @@ func (plugin *Plugin) Call(name string, data []byte) (uint32, []byte, error) {
 		return 1, []byte{}, errors.New(fmt.Sprintf("Function %s has %v results, expected 0 or 1", name, n))
 	}
 
-	if plugin.guestRuntime.Init != nil && (isStart || !plugin.guestRuntime.initialized) {
+	var isStart = name == "_start"
+	if plugin.guestRuntime.Init != nil && !isStart && !plugin.guestRuntime.initialized {
 		err := plugin.guestRuntime.Init()
 		if err != nil {
 			return 1, []byte{}, errors.New(fmt.Sprintf("failed to initialize runtime: %v", err))

--- a/extism_test.go
+++ b/extism_test.go
@@ -525,7 +525,6 @@ func TestHelloHaskell(t *testing.T) {
 			logs := buf.String()
 
 			assert.Contains(t, logs, "Initialized Haskell language runtime.")
-			assert.Contains(t, logs, "Calling hs_exit")
 		}
 	}
 }

--- a/runtime.go
+++ b/runtime.go
@@ -58,7 +58,15 @@ func haskellRuntime(p *Plugin, m api.Module) (GuestRuntime, bool) {
 		return GuestRuntime{}, false
 	}
 
+	reactorInit := m.ExportedFunction("_initialize")
+
 	init := func() error {
+		if reactorInit != nil {
+			_, err := reactorInit.Call(p.Runtime.ctx)
+			if err != nil {
+				p.Logf(Error, "Error running reactor _initialize: %s", err.Error())
+			}
+		}
 		_, err := initFunc.Call(p.Runtime.ctx, 0, 0)
 		if err == nil {
 			p.Log(Debug, "Initialized Haskell language runtime.")

--- a/runtime.go
+++ b/runtime.go
@@ -4,7 +4,7 @@ import (
 	"github.com/tetratelabs/wazero/api"
 )
 
-// TODO: test runtime initialization/cleanup for WASI and Haskell
+// TODO: test runtime initialization for WASI and Haskell
 
 type RuntimeType uint8
 
@@ -53,11 +53,6 @@ func haskellRuntime(p *Plugin, m api.Module) (GuestRuntime, bool) {
 		p.Logf(Trace, "hs_init function found with type %v", params)
 	}
 
-	cleanupFunc := m.ExportedFunction("hs_exit")
-	if cleanupFunc == nil {
-		return GuestRuntime{}, false
-	}
-
 	reactorInit := m.ExportedFunction("_initialize")
 
 	init := func() error {
@@ -79,7 +74,7 @@ func haskellRuntime(p *Plugin, m api.Module) (GuestRuntime, bool) {
 	return GuestRuntime{Type: Haskell, Init: init}, true
 }
 
-// Check for initialization and cleanup functions defined by the WASI standard
+// Check for initialization functions defined by the WASI standard
 func wasiRuntime(p *Plugin, m api.Module) (GuestRuntime, bool) {
 	if !p.Runtime.hasWasi {
 		return GuestRuntime{}, false

--- a/runtime.go
+++ b/runtime.go
@@ -16,7 +16,6 @@ const (
 
 type GuestRuntime struct {
 	Type        RuntimeType
-	InitOnce    func() error
 	Init        func() error
 	initialized bool
 }
@@ -100,7 +99,7 @@ func reactorModule(m api.Module, p *Plugin) (GuestRuntime, bool) {
 	p.Logf(Trace, "WASI runtime detected")
 	p.Logf(Trace, "Reactor module detected")
 
-	return GuestRuntime{Type: Wasi, InitOnce: init, Init: nil}, true
+	return GuestRuntime{Type: Wasi, Init: init}, true
 }
 
 // Check for `__wasm__call_ctors`, this is used by WASI to


### PR DESCRIPTION
- Removes `GuestRuntime.Cleanup` and `GuestRuntime.InitOnce`
- Calls GuestRuntime.Init once for the lifetime of a Plugin
- Improves Haskell reactor support

See: https://github.com/extism/extism/pull/411