### PR TITLE
refactor: change host function API and hide GuestRuntime

### DIFF
--- a/extism.go
+++ b/extism.go
@@ -89,7 +89,7 @@ type Plugin struct {
 	LastStatusCode int
 	log            func(LogLevel, string)
 	logLevel       LogLevel
-	guestRuntime   GuestRuntime
+	guestRuntime   guestRuntime
 }
 
 func logStd(level LogLevel, message string) {
@@ -363,7 +363,7 @@ func NewPlugin(
 				log:            logStd,
 				logLevel:       logLevel}
 
-			p.guestRuntime = guestRuntime(p)
+			p.guestRuntime = detectGuestRuntime(p)
 			return p, nil
 		}
 
@@ -470,8 +470,8 @@ func (plugin *Plugin) Call(name string, data []byte) (uint32, []byte, error) {
 	}
 
 	var isStart = name == "_start"
-	if plugin.guestRuntime.Init != nil && !isStart && !plugin.guestRuntime.initialized {
-		err := plugin.guestRuntime.Init()
+	if plugin.guestRuntime.init != nil && !isStart && !plugin.guestRuntime.initialized {
+		err := plugin.guestRuntime.init()
 		if err != nil {
 			return 1, []byte{}, errors.New(fmt.Sprintf("failed to initialize runtime: %v", err))
 		}

--- a/extism_test.go
+++ b/extism_test.go
@@ -224,18 +224,18 @@ func TestExit(t *testing.T) {
 func TestHost_simple(t *testing.T) {
 	manifest := manifest("host.wasm")
 
-	mult := HostFunction{
-		Name:      "mult",
-		Namespace: "env",
-		Callback: func(ctx context.Context, plugin *CurrentPlugin, userData interface{}, stack []uint64) {
+	mult := NewHostFunctionWithStack(
+		"mult",
+		"env",
+		func(ctx context.Context, plugin *CurrentPlugin, stack []uint64) {
 			a := api.DecodeI32(stack[0])
 			b := api.DecodeI32(stack[1])
 
 			stack[0] = api.EncodeI32(a * b)
 		},
-		Params:  []api.ValueType{api.ValueTypeI64, api.ValueTypeI64},
-		Results: []api.ValueType{api.ValueTypeI64},
-	}
+		[]api.ValueType{api.ValueTypeI64, api.ValueTypeI64},
+		api.ValueTypeI64,
+	)
 
 	if plugin, ok := plugin(t, manifest, mult); ok {
 		defer plugin.Close()
@@ -254,10 +254,10 @@ func TestHost_simple(t *testing.T) {
 func TestHost_memory(t *testing.T) {
 	manifest := manifest("host_memory.wasm")
 
-	mult := HostFunction{
-		Name:      "to_upper",
-		Namespace: "host",
-		Callback: func(ctx context.Context, plugin *CurrentPlugin, userData interface{}, stack []uint64) {
+	mult := NewHostFunctionWithStack(
+		"to_upper",
+		"host",
+		func(ctx context.Context, plugin *CurrentPlugin, stack []uint64) {
 			offset := stack[0]
 			buffer, err := plugin.ReadBytes(offset)
 			if err != nil {
@@ -276,9 +276,9 @@ func TestHost_memory(t *testing.T) {
 
 			stack[0] = offset
 		},
-		Params:  []api.ValueType{api.ValueTypeI64},
-		Results: []api.ValueType{api.ValueTypeI64},
-	}
+		[]api.ValueType{api.ValueTypeI64},
+		api.ValueTypeI64,
+	)
 
 	if plugin, ok := plugin(t, manifest, mult); ok {
 		defer plugin.Close()
@@ -302,10 +302,10 @@ func TestHost_multiple(t *testing.T) {
 		EnableWasi:   true,
 	}
 
-	green_message := HostFunction{
-		Name:      "hostGreenMessage",
-		Namespace: "env",
-		Callback: func(ctx context.Context, plugin *CurrentPlugin, userData interface{}, stack []uint64) {
+	green_message := NewHostFunctionWithStack(
+		"hostGreenMessage",
+		"env",
+		func(ctx context.Context, plugin *CurrentPlugin, stack []uint64) {
 			offset := stack[0]
 			input, err := plugin.ReadString(offset)
 
@@ -324,14 +324,14 @@ func TestHost_multiple(t *testing.T) {
 
 			stack[0] = offset
 		},
-		Params:  []api.ValueType{api.ValueTypeI64},
-		Results: []api.ValueType{api.ValueTypeI64},
-	}
+		[]api.ValueType{api.ValueTypeI64},
+		api.ValueTypeI64,
+	)
 
-	purple_message := HostFunction{
-		Name:      "hostPurpleMessage",
-		Namespace: "env",
-		Callback: func(ctx context.Context, plugin *CurrentPlugin, userData interface{}, stack []uint64) {
+	purple_message := NewHostFunctionWithStack(
+		"hostPurpleMessage",
+		"env",
+		func(ctx context.Context, plugin *CurrentPlugin, stack []uint64) {
 			offset := stack[0]
 			input, err := plugin.ReadString(offset)
 
@@ -350,9 +350,9 @@ func TestHost_multiple(t *testing.T) {
 
 			stack[0] = offset
 		},
-		Params:  []api.ValueType{api.ValueTypeI64},
-		Results: []api.ValueType{api.ValueTypeI64},
-	}
+		[]api.ValueType{api.ValueTypeI64},
+		api.ValueTypeI64,
+	)
 
 	hostFunctions := []HostFunction{
 		purple_message,


### PR DESCRIPTION
I wanted to change these before hitting 1.0 for the go-sdk:
- I think we should hide HostFunction creation behind a function so that we have flexibility of adding new function callbacks in the future
- And I think GuestRuntime is an implementation detail and doesn't need to be public