### PR TITLE
fix: use uint64 for `Manifest.Timeout`

### DIFF
--- a/extism.go
+++ b/extism.go
@@ -212,7 +212,7 @@ type Manifest struct {
 	Config       map[string]string `json:"config,omitempty"`
 	AllowedHosts []string          `json:"allowed_hosts,omitempty"`
 	AllowedPaths map[string]string `json:"allowed_paths,omitempty"`
-	Timeout      time.Duration     `json:"timeout_ms,omitempty"`
+	Timeout      uint64            `json:"timeout_ms,omitempty"`
 }
 
 // Close closes the plugin by freeing the underlying resources.
@@ -359,7 +359,7 @@ func NewPlugin(
 				AllowedHosts:   manifest.AllowedHosts,
 				AllowedPaths:   manifest.AllowedPaths,
 				LastStatusCode: 0,
-				Timeout:        manifest.Timeout,
+				Timeout:        time.Duration(manifest.Timeout) * time.Millisecond,
 				log:            logStd,
 				logLevel:       logLevel}
 

--- a/extism.go
+++ b/extism.go
@@ -445,10 +445,8 @@ func (plugin *Plugin) Call(name string, data []byte) (uint32, []byte, error) {
 	ctx := plugin.Runtime.ctx
 
 	if plugin.Timeout > 0 {
-		timeout := time.Duration(plugin.Timeout) * time.Millisecond
-
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(plugin.Runtime.ctx, timeout)
+		ctx, cancel = context.WithTimeout(plugin.Runtime.ctx, plugin.Timeout)
 		defer cancel()
 	}
 


### PR DESCRIPTION
When setting `Manifest.Timeout` I got hung up because it is a `time.Duration` value, so I was setting it to `time.Milliseconds * time.Duration(3000)` instead of just `time.Duration(3000)`. This PR switches `Manifest.Timeout` to be a `uint64` since it is already "timeout in milliseconds" - @mhmd-azeez if you think there's a better fix for this let me know!