### PR TITLE
fix: copy buffers read from wasm memory

### DIFF
--- a/extism_test.go
+++ b/extism_test.go
@@ -564,6 +564,15 @@ func TestVar(t *testing.T) {
 
 			assert.Equal(t, expected, actual)
 		}
+
+		exit, _, err = plugin.Call("run_test", []byte{})
+
+		if assertCall(t, err, exit) {
+			actual := uintFromLEBytes(plugin.Var["a"])
+			expected := uint(40)
+
+			assert.Equal(t, expected, actual)
+		}
 	}
 
 }

--- a/extism_test.go
+++ b/extism_test.go
@@ -619,14 +619,14 @@ func TestMultipleCallsOutput(t *testing.T) {
 			return
 		}
 
-		exit, output2, err := plugin.Call("count_vowels", []byte("bbb"))
+		exit, output2, err := plugin.Call("count_vowels", []byte("bbba"))
 
 		if !assertCall(t, err, exit) {
 			return
 		}
 
-		assert.Equal(t, `{"count": 3}`, string(output1))
-		assert.Equal(t, `{"count": 0}`, string(output2))
+		assert.Equal(t, `{"count":3,"total":3,"vowels":"aeiouAEIOU"}`, string(output1))
+		assert.Equal(t, `{"count":1,"total":4,"vowels":"aeiouAEIOU"}`, string(output2))
 	}
 }
 

--- a/host.go
+++ b/host.go
@@ -185,7 +185,10 @@ func (p *CurrentPlugin) ReadBytes(offset uint64) ([]byte, error) {
 		return []byte{}, fmt.Errorf("Invalid memory block")
 	}
 
-	return buffer, nil
+	cpy := make([]byte, len(buffer))
+	copy(cpy, buffer)
+
+	return cpy, nil
 }
 
 func buildHostModule(ctx context.Context, rt wazero.Runtime, name string, funcs []HostFunction) (api.Module, error) {


### PR DESCRIPTION
By default, [Wazero's `api.Memory.Read`](https://github.com/tetratelabs/wazero/blob/103e223d1d0605d0a3ae7089804ae935e302510b/api/wasm.go#L637) returns a *view* of the underlying memory:

> ### Write-through
> 
> This returns a view of the underlying memory, not a copy. This means any
> writes to the slice returned are visible to Wasm, and any updates from
> Wasm are visible reading the returned slice.
> 
> For example:
> 	buf, _ = memory.Read(offset, byteCount)
> 	buf[1] = 'a' // writes through to memory, meaning Wasm code see 'a'.
> 
> If you don't intend-write through, make a copy of the returned slice.

This caused an issue for `varSet` because it basically set the value of the variable to a view of the underlying memory. And before every call, we call `extism_reset` to reset the wasm memory. So this would basically zero out the values of all variables.

We have two choices:
1. Copy the buffer in `ReadBytes` which is what I have done in this PR
2. Copy the buffer in `varSet`. This allows for fine grain control over reading wasm memory, but it might create similar (hard to track) bugs in the future