### PR TITLE
doc: remove log from example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ kvRead := extism.NewHostFunctionWithStack(
             value = []byte{0, 0, 0, 0}
         }
 
-        fmt.Printf("Read %v from key=%s\n", binary.LittleEndian.Uint32(value), key)
         stack[0], err = p.WriteBytes(value)
     },
     []api.ValueType{extism.PTR},
@@ -182,8 +181,6 @@ kvWrite := extism.NewHostFunctionWithStack(
         if err != nil {
             panic(err)
         }
-
-        fmt.Printf("Writing value=%v from key=%s\n", binary.LittleEndian.Uint32(value), key)
 
         kvStore[key] = value
     },


### PR DESCRIPTION
Something (possibly the LE conversion) was causing a runtime error reading out of bounds when I ran these examples. I don't have time to debug, but figure we're not really losing anything if we just remove these from the example code so they don't fail for other users who are trying the code.