### PR TITLE
feat: compilation cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,25 @@ exit, out, err = plugin.Call("count_vowels", []byte("Hello, World!"))
 // => {"count": 3, "total": 6, "vowels": "aeiouAEIOU"}
 ```
 
+### Enabling Compilation Cache
+While Wazero (the underlying Wasm runtime) is very fast in initializing modules, you can make subsequent initializations even faster by enabling the compilation cache:
+
+```go
+ctx := context.Background()
+cache := wazero.NewCompilationCache()
+defer cache.Close(ctx)
+
+manifest := Manifest{Wasm: []Wasm{WasmFile{Path: "wasm/noop.wasm"}}}
+
+config := PluginConfig{
+    EnableWasi:    true,
+    ModuleConfig:  wazero.NewModuleConfig(),
+    RuntimeConfig: wazero.NewRuntimeConfig().WithCompilationCache(cache),
+}
+
+_, err := NewPlugin(ctx, manifest, config, []HostFunction{})
+```
+
 ## Build example plugins
 Since our [example plugins](./plugins/) are also written in Go, for compiling them we use [TinyGo](https://tinygo.org/):
 ```sh

--- a/extism_test.go
+++ b/extism_test.go
@@ -667,6 +667,56 @@ func TestHelloHaskell(t *testing.T) {
 	}
 }
 
+func BenchmarkInitialize(b *testing.B) {
+	ctx := context.Background()
+	cache := wazero.NewCompilationCache()
+	defer cache.Close(ctx)
+
+	b.ResetTimer()
+	b.Run("noop", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			manifest := Manifest{Wasm: []Wasm{WasmFile{Path: "wasm/noop.wasm"}}}
+
+			config := PluginConfig{
+				EnableWasi:    true,
+				ModuleConfig:  wazero.NewModuleConfig(),
+				RuntimeConfig: wazero.NewRuntimeConfig(),
+			}
+
+			_, err := NewPlugin(ctx, manifest, config, []HostFunction{})
+			if err != nil {
+				panic(err)
+			}
+		}
+	})
+}
+
+func BenchmarkInitializeWithCache(b *testing.B) {
+	ctx := context.Background()
+	cache := wazero.NewCompilationCache()
+	defer cache.Close(ctx)
+
+	b.ResetTimer()
+	b.Run("noop", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			manifest := Manifest{Wasm: []Wasm{WasmFile{Path: "wasm/noop.wasm"}}}
+
+			config := PluginConfig{
+				EnableWasi:    true,
+				ModuleConfig:  wazero.NewModuleConfig(),
+				RuntimeConfig: wazero.NewRuntimeConfig().WithCompilationCache(cache),
+			}
+
+			_, err := NewPlugin(ctx, manifest, config, []HostFunction{})
+			if err != nil {
+				panic(err)
+			}
+		}
+	})
+}
+
 func BenchmarkNoop(b *testing.B) {
 	ctx := context.Background()
 	cache := wazero.NewCompilationCache()


### PR DESCRIPTION
This PR is related to https://github.com/extism/extism/pull/605

```
PS D:\dylibso\go-sdk> go test -benchmem -run=^$ -bench .
goos: windows
goarch: amd64
pkg: github.com/extism/go-sdk
cpu: 13th Gen Intel(R) Core(TM) i7-1365U
BenchmarkInitialize/noop-12                         385           3051739 ns/op         2942236 B/op       2751 allocs/op
BenchmarkInitializeWithCache/noop-12                2112            504269 ns/op         1686493 B/op       1554 allocs/op
```

Without using compilation cache: 3ms
with compilation cache: 0.5ms

Since we're already exposing `wazero.RuntimeConfig`, I think we just need to mention it in the README