### PR TITLE
feat: abstract away Wazero's api.ValueType and api.EncodeXX/api.DecodeXX

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ kvRead := extism.NewHostFunctionWithStack(
 
         stack[0], err = p.WriteBytes(value)
     },
-    []api.ValueType{extism.PTR},
-    []api.ValueType{extism.PTR},
+    []ValueType{ValueTypePTR},
+    []ValueType{ValueTypePTR},
 )
 
 kvWrite := extism.NewHostFunctionWithStack(
@@ -184,8 +184,8 @@ kvWrite := extism.NewHostFunctionWithStack(
 
         kvStore[key] = value
     },
-    []api.ValueType{extism.PTR, extism.PTR},
-    []api.ValueType{},
+    []ValueType{ValueTypePTR, ValueTypePTR},
+    []ValueType{},
 )
 ```
 

--- a/extism_test.go
+++ b/extism_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tetratelabs/wazero"
-	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/sys"
 )
 
@@ -227,13 +226,13 @@ func TestHost_simple(t *testing.T) {
 	mult := NewHostFunctionWithStack(
 		"mult",
 		func(ctx context.Context, plugin *CurrentPlugin, stack []uint64) {
-			a := api.DecodeI32(stack[0])
-			b := api.DecodeI32(stack[1])
+			a := DecodeI32(stack[0])
+			b := DecodeI32(stack[1])
 
-			stack[0] = api.EncodeI32(a * b)
+			stack[0] = EncodeI32(a * b)
 		},
-		[]api.ValueType{PTR, PTR},
-		[]api.ValueType{PTR},
+		[]ValueType{ValueTypePTR, ValueTypePTR},
+		[]ValueType{ValueTypePTR},
 	)
 
 	if plugin, ok := plugin(t, manifest, mult); ok {
@@ -274,8 +273,8 @@ func TestHost_memory(t *testing.T) {
 
 			stack[0] = offset
 		},
-		[]api.ValueType{PTR},
-		[]api.ValueType{PTR},
+		[]ValueType{ValueTypePTR},
+		[]ValueType{ValueTypePTR},
 	)
 
 	mult.SetNamespace("host")
@@ -323,8 +322,8 @@ func TestHost_multiple(t *testing.T) {
 
 			stack[0] = offset
 		},
-		[]api.ValueType{PTR},
-		[]api.ValueType{PTR},
+		[]ValueType{ValueTypePTR},
+		[]ValueType{ValueTypePTR},
 	)
 
 	purple_message := NewHostFunctionWithStack(
@@ -348,8 +347,8 @@ func TestHost_multiple(t *testing.T) {
 
 			stack[0] = offset
 		},
-		[]api.ValueType{PTR},
-		[]api.ValueType{PTR},
+		[]ValueType{ValueTypePTR},
+		[]ValueType{ValueTypePTR},
 	)
 
 	hostFunctions := []HostFunction{


### PR DESCRIPTION
Currently we are exposing these wazero APIs:
- [`RuntimeConfig`](https://github.com/tetratelabs/wazero/blob/d39d84505ad8021b5ba47bbc9dd55911b9b0406f/config.go#L40-L171)
- [`ModuleConfig`](https://github.com/tetratelabs/wazero/blob/d39d84505ad8021b5ba47bbc9dd55911b9b0406f/config.go#L444-L638)
- [`api.ValueType`](https://github.com/tetratelabs/wazero/blob/d39d84505ad8021b5ba47bbc9dd55911b9b0406f/api/wasm.go#L83-L110)
- [`api.EncodeXX/api.DecodeXX`](https://github.com/tetratelabs/wazero/blob/d39d84505ad8021b5ba47bbc9dd55911b9b0406f/api/wasm.go#L693-L755)
- [`api.Memory`](https://github.com/tetratelabs/wazero/blob/d39d84505ad8021b5ba47bbc9dd55911b9b0406f/api/wasm.go#L557-L673)

The idea of this PR is hide away wazero from normal usage. If the user doesn't need any advanced configuration or functionality, then they shouldn't have to know about Wazero. That's why we are abstracting away  `api.EncodeXX/api.DecodeXX` and `api.ValueType` since they will be used whenever you write a host function.

`RuntimeConfig` and `ModuleConfig` are about giving the user fine grain control of the underyling configurations. We expose some of the functionality as part of the manifest as well, [see this for a more detailed breakdown](https://github.com/extism/go-sdk/pull/43#issuecomment-1833735502).

And `api.Memory` is for write-through access of the underyling memory.

The only thing I am a bit worried about is [`RuntimeConfig.WithCloseOnContextDone`](https://github.com/tetratelabs/wazero/blob/5796897f37852bf2042cd63959ce4ff673c4366e/config.go#L170C2-L170C24) because by default wazero sets it to false, which might be very confusing. We do set it to true if the user configures a timeout though.