### PR TITLE
chore: bump wazero version

### DIFF
--- a/extism_test.go
+++ b/extism_test.go
@@ -770,7 +770,7 @@ func TestEnableExperimentalFeature(t *testing.T) {
 	var buf bytes.Buffer
 
 	// Set context to one that has an experimental listener
-	ctx := context.WithValue(context.Background(), experimental.FunctionListenerFactoryKey{}, logging.NewLoggingListenerFactory(&buf))
+	ctx := experimental.WithFunctionListenerFactory(context.Background(), logging.NewHostLoggingListenerFactory(&buf, logging.LogScopeAll))
 
 	manifest := manifest("sleep.wasm")
 	manifest.Config["duration"] = "0" // sleep for 0 seconds
@@ -790,7 +790,7 @@ func TestEnableExperimentalFeature(t *testing.T) {
 	defer plugin.Close()
 
 	var buf2 bytes.Buffer
-	ctx = context.WithValue(context.Background(), experimental.FunctionListenerFactoryKey{}, logging.NewLoggingListenerFactory(&buf2))
+	ctx = experimental.WithFunctionListenerFactory(context.Background(), logging.NewHostLoggingListenerFactory(&buf2, logging.LogScopeAll))
 	exit, out, err := plugin.CallWithContext(ctx, "run_test", []byte{})
 
 	if assertCall(t, err, exit) {

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,14 @@ module github.com/extism/go-sdk
 
 go 1.20
 
-require github.com/tetratelabs/wazero v1.3.0
+require (
+	github.com/gobwas/glob v0.2.3
+	github.com/stretchr/testify v1.8.4
+	github.com/tetratelabs/wazero v1.7.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.8.4 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/gobwas/glob v0.2.3
 	github.com/stretchr/testify v1.8.4
-	github.com/tetratelabs/wazero v1.7.0
+	github.com/tetratelabs/wazero v1.7.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,9 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/tetratelabs/wazero v1.3.0 h1:nqw7zCldxE06B8zSZAY0ACrR9OH5QCcPwYmYlwtcwtE=
-github.com/tetratelabs/wazero v1.3.0/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.7.0 h1:jg5qPydno59wqjpGrHph81lbtHzTrWzwwtD4cD88+hQ=
+github.com/tetratelabs/wazero v1.7.0/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/tetratelabs/wazero v1.7.0 h1:jg5qPydno59wqjpGrHph81lbtHzTrWzwwtD4cD88+hQ=
-github.com/tetratelabs/wazero v1.7.0/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
+github.com/tetratelabs/wazero v1.7.3 h1:PBH5KVahrt3S2AHgEjKu4u+LlDbbk+nsGE3KLucy6Rw=
+github.com/tetratelabs/wazero v1.7.3/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Opening this up as a draft for now for discussion. 

This PR brings `wazero` up to the latest version, which introduces their new optimizing compiler. I've added benchmarks from the current version we use `v1.3.0`, and the latest `v1.7.0`:


`v1.3.0`:

```
goos: linux
goarch: amd64
pkg: github.com/extism/go-sdk
cpu: 12th Gen Intel(R) Core(TM) i7-1255U
BenchmarkInitialize/noop-12                  314           3610336 ns/op         2850623 B/op       2744 allocs/op
BenchmarkInitializeWithCache/noop-12                2060            549867 ns/op         1630131 B/op       1554 allocs/op
BenchmarkNoop/noop-12                             245217              4664 ns/op           26216 B/op         22 allocs/op
BenchmarkReplace/8192-12                            5328            249861 ns/op          32.79 MB/s       34408 B/op         23 allocs/op
BenchmarkReplace/16383-12                           2366            495646 ns/op          33.06 MB/s       42600 B/op         23 allocs/op
BenchmarkReplace/32768-12                           1046           1110322 ns/op          29.51 MB/s       58985 B/op         23 allocs/op
BenchmarkReplace/empty-12                         222662              4755 ns/op           26216 B/op         22 allocs/op
BenchmarkReplace/2048-12                           17350             66603 ns/op          30.75 MB/s       28264 B/op         23 allocs/op
BenchmarkReplace/4096-12                            9249            122996 ns/op          33.30 MB/s       30312 B/op         23 allocs/op

```


`v1.7.0`:
```
goos: linux
goarch: amd64
pkg: github.com/extism/go-sdk
cpu: 12th Gen Intel(R) Core(TM) i7-1255U
BenchmarkInitialize/noop-12                   64          17807498 ns/op         5553731 B/op       8519 allocs/op
BenchmarkInitializeWithCache/noop-12                1300            798052 ns/op         1830382 B/op       1954 allocs/op
BenchmarkNoop/noop-12                              67366             17587 ns/op           70142 B/op         23 allocs/op
BenchmarkReplace/8192-12                            5043            247079 ns/op          33.16 MB/s       78329 B/op         24 allocs/op
BenchmarkReplace/16383-12                           2517            457056 ns/op          35.85 MB/s       86523 B/op         24 allocs/op
BenchmarkReplace/32768-12                           1292            940309 ns/op          34.85 MB/s      102912 B/op         24 allocs/op
BenchmarkReplace/empty-12                          67363             16843 ns/op           70137 B/op         23 allocs/op
BenchmarkReplace/2048-12                           15170             81431 ns/op          25.15 MB/s       72183 B/op         24 allocs/op
BenchmarkReplace/4096-12                            8074            134374 ns/op          30.48 MB/s       74230 B/op         24 allocs/op

```