### PR TITLE
fix: use log.Print instead of log.Printf in logStd

### DIFF
--- a/extism.go
+++ b/extism.go
@@ -96,7 +96,7 @@ type Plugin struct {
 }
 
 func logStd(level LogLevel, message string) {
-	log.Printf(message)
+	log.Print(message)
 }
 
 // SetLogger sets a custom logging callback


### PR DESCRIPTION
Fixes an issue where `%` is interpreted as a format identifier instead of printed verbatim