### PR TITLE
fix: Remove PluginConfig.LogLevel and set default log level to Off

### DIFF
--- a/extism_test.go
+++ b/extism_test.go
@@ -435,11 +435,6 @@ func TestLog_default(t *testing.T) {
 		log.SetOutput(os.Stderr)
 	}()
 
-	type LogEntry struct {
-		message string
-		level   LogLevel
-	}
-
 	if plugin, ok := plugin(t, manifest); ok {
 		defer plugin.Close()
 

--- a/host.go
+++ b/host.go
@@ -334,7 +334,6 @@ func buildEnvModule(ctx context.Context, rt wazero.Runtime, extism api.Module) (
 	logFunc("log_info", LogLevelInfo)
 	logFunc("log_warn", LogLevelWarn)
 	logFunc("log_error", LogLevelError)
-	logFunc("log_trace", LogLevelTrace)
 
 	return builder.Instantiate(ctx)
 }
@@ -586,7 +585,7 @@ func getLogLevel(ctx context.Context, m api.Module) int32 {
 	// if _, ok := ctx.Value(PluginCtxKey("plugin")).(*Plugin); ok {
 	// 	panic("Invalid context, `plugin` key not found")
 	// }
-	return pluginLogLevel.Load()
+	return LogLevel(pluginLogLevel.Load()).ExtismCompat()
 }
 
 // EncodeI32 encodes the input as a ValueTypeI32.


### PR DESCRIPTION
This fixes a bug where log level is Trace by default and removes PluginConfig.LogLevel since we can't enforce it anymore