### PR TITLE
Exposed extism module and added methods to get exported functions

### DIFF
--- a/extism.go
+++ b/extism.go
@@ -486,7 +486,7 @@ func NewPlugin(
 		if data.Hash != "" {
 			calculatedHash := calculateHash(data.Data)
 			if data.Hash != calculatedHash {
-				return nil, fmt.Errorf("hash mismatch for Module '%s'", data.Name)
+				return nil, fmt.Errorf("hash mismatch for module '%s'", data.Name)
 			}
 		}
 
@@ -534,7 +534,7 @@ func NewPlugin(
 		i++
 	}
 
-	return nil, errors.New("no main Module found")
+	return nil, errors.New("no main module found")
 }
 
 // SetInput sets the input data for the plugin to be used in the next WebAssembly function call.

--- a/extism.go
+++ b/extism.go
@@ -449,11 +449,11 @@ func NewPlugin(
 		moduleConfig = moduleConfig.WithStderr(os.Stderr).WithStdout(os.Stdout)
 	}
 
-	// Try to find the main Module:
-	//  - There is always one main Module
-	//  - If a Wasm value has the Name field set to "main" then use that Module
-	//  - If there is only one Module in the manifest then that is the main Module by default
-	//  - Otherwise the last Module listed is the main Module
+	// Try to find the main module:
+	//  - There is always one main module
+	//  - If a Wasm value has the Name field set to "main" then use that module
+	//  - If there is only one module in the manifest then that is the main module by default
+	//  - Otherwise the last module listed is the main module
 
 	var trace *observe.TraceCtx
 	for i, wasm := range manifest.Wasm {
@@ -480,7 +480,7 @@ func NewPlugin(
 		_, okm := modules[data.Name]
 
 		if data.Name == "extism:host/env" || okh || okm {
-			return nil, fmt.Errorf("Module name collision: '%s'", data.Name)
+			return nil, fmt.Errorf("module name collision: '%s'", data.Name)
 		}
 
 		if data.Hash != "" {

--- a/extism_test.go
+++ b/extism_test.go
@@ -550,7 +550,7 @@ func TestTimeout(t *testing.T) {
 	exit, _, err := plugin.Call("run_test", []byte{})
 
 	assert.Equal(t, sys.ExitCodeDeadlineExceeded, exit, "Exit code must be `sys.ExitCodeDeadlineExceeded`")
-	assert.Equal(t, "Module closed with context deadline exceeded", err.Error())
+	assert.Equal(t, "module closed with context deadline exceeded", err.Error())
 }
 
 func TestCancel(t *testing.T) {
@@ -581,7 +581,7 @@ func TestCancel(t *testing.T) {
 	exit, _, err := plugin.CallWithContext(ctx, "run_test", []byte{})
 
 	assert.Equal(t, sys.ExitCodeContextCanceled, exit, "Exit code must be `sys.ExitCodeContextCanceled`")
-	assert.Equal(t, "Module closed with context canceled", err.Error())
+	assert.Equal(t, "module closed with context canceled", err.Error())
 }
 
 func TestVar(t *testing.T) {
@@ -781,7 +781,7 @@ func TestJsonManifest(t *testing.T) {
 		exit, _, err := plugin.Call("run_test", []byte{})
 
 		assert.Equal(t, sys.ExitCodeDeadlineExceeded, exit, "Exit code must be `sys.ExitCodeDeadlineExceeded`")
-		assert.Equal(t, "Module closed with context deadline exceeded", err.Error())
+		assert.Equal(t, "module closed with context deadline exceeded", err.Error())
 	}
 }
 

--- a/extism_test.go
+++ b/extism_test.go
@@ -550,7 +550,7 @@ func TestTimeout(t *testing.T) {
 	exit, _, err := plugin.Call("run_test", []byte{})
 
 	assert.Equal(t, sys.ExitCodeDeadlineExceeded, exit, "Exit code must be `sys.ExitCodeDeadlineExceeded`")
-	assert.Equal(t, "module closed with context deadline exceeded", err.Error())
+	assert.Equal(t, "Module closed with context deadline exceeded", err.Error())
 }
 
 func TestCancel(t *testing.T) {
@@ -581,7 +581,7 @@ func TestCancel(t *testing.T) {
 	exit, _, err := plugin.CallWithContext(ctx, "run_test", []byte{})
 
 	assert.Equal(t, sys.ExitCodeContextCanceled, exit, "Exit code must be `sys.ExitCodeContextCanceled`")
-	assert.Equal(t, "module closed with context canceled", err.Error())
+	assert.Equal(t, "Module closed with context canceled", err.Error())
 }
 
 func TestVar(t *testing.T) {
@@ -781,7 +781,7 @@ func TestJsonManifest(t *testing.T) {
 		exit, _, err := plugin.Call("run_test", []byte{})
 
 		assert.Equal(t, sys.ExitCodeDeadlineExceeded, exit, "Exit code must be `sys.ExitCodeDeadlineExceeded`")
-		assert.Equal(t, "module closed with context deadline exceeded", err.Error())
+		assert.Equal(t, "Module closed with context deadline exceeded", err.Error())
 	}
 }
 

--- a/module.go
+++ b/module.go
@@ -1,0 +1,30 @@
+package extism
+
+import "github.com/tetratelabs/wazero/api"
+
+// Module is a wrapper around a wazero module. It allows us to provide
+// our own API and stability guarantees despite any changes that wazero
+// may choose to make.
+type Module struct {
+	inner api.Module
+}
+
+// ExportedFunctions returns a map of functions exported from the module
+// keyed by the function name.
+func (m *Module) ExportedFunctions() map[string]FunctionDefinition {
+	v := make(map[string]FunctionDefinition)
+	for name, def := range m.inner.ExportedFunctionDefinitions() {
+		v[name] = FunctionDefinition{inner: def}
+	}
+	return v
+}
+
+// FunctionDefinition represents a function defined in a module. It provides
+// a wrapper around the underlying wazero function definition.
+type FunctionDefinition struct {
+	inner api.FunctionDefinition
+}
+
+func (f *FunctionDefinition) Name() string {
+	return f.inner.Name()
+}

--- a/runtime.go
+++ b/runtime.go
@@ -25,12 +25,12 @@ type guestRuntime struct {
 func detectGuestRuntime(ctx context.Context, p *Plugin) guestRuntime {
 	m := p.Main
 
-	runtime, ok := haskellRuntime(ctx, p, m.module)
+	runtime, ok := haskellRuntime(ctx, p, m.inner)
 	if ok {
 		return runtime
 	}
 
-	runtime, ok = wasiRuntime(ctx, p, m.module)
+	runtime, ok = wasiRuntime(ctx, p, m.inner)
 	if ok {
 		return runtime
 	}
@@ -99,7 +99,7 @@ func reactorModule(ctx context.Context, m api.Module, p *Plugin) (guestRuntime, 
 	}
 
 	p.Logf(LogLevelTrace, "WASI runtime detected")
-	p.Logf(LogLevelTrace, "Reactor module detected")
+	p.Logf(LogLevelTrace, "Reactor Module detected")
 
 	return guestRuntime{runtimeType: Wasi, init: init}, true
 }
@@ -113,7 +113,7 @@ func commandModule(ctx context.Context, m api.Module, p *Plugin) (guestRuntime, 
 	}
 
 	p.Logf(LogLevelTrace, "WASI runtime detected")
-	p.Logf(LogLevelTrace, "Command module detected")
+	p.Logf(LogLevelTrace, "Command Module detected")
 
 	return guestRuntime{runtimeType: Wasi, init: init}, true
 }

--- a/runtime.go
+++ b/runtime.go
@@ -99,7 +99,7 @@ func reactorModule(ctx context.Context, m api.Module, p *Plugin) (guestRuntime, 
 	}
 
 	p.Logf(LogLevelTrace, "WASI runtime detected")
-	p.Logf(LogLevelTrace, "Reactor Module detected")
+	p.Logf(LogLevelTrace, "Reactor module detected")
 
 	return guestRuntime{runtimeType: Wasi, init: init}, true
 }
@@ -113,7 +113,7 @@ func commandModule(ctx context.Context, m api.Module, p *Plugin) (guestRuntime, 
 	}
 
 	p.Logf(LogLevelTrace, "WASI runtime detected")
-	p.Logf(LogLevelTrace, "Command Module detected")
+	p.Logf(LogLevelTrace, "Command module detected")
 
 	return guestRuntime{runtimeType: Wasi, init: init}, true
 }


### PR DESCRIPTION
This PR does a couple of things:
* It exposes the extism `module` struct.
* It adds methods to get any exported functions from the module.
* It adds a struct to wrap the wazero function definition, allowing Extism to control the API, while also exposing some of the behaviors provided by wazero.
* It removes the `module.wasm` bytes from the `module` struct. It was unused as far as I could tell and I don't see any reason (while it's unused at least) that we wouldn't want the GC to be able to garbage collect that slice, especially when we're dealing with large modules.