### PR TITLE
Support concurrent plugin execution through instances

### DIFF
--- a/extism.go
+++ b/extism.go
@@ -133,8 +133,8 @@ func logStd(level LogLevel, message string) {
 	log.Print(message)
 }
 
-func (p *PluginInstance) Module() Module {
-	return Module{inner: p.module}
+func (p *PluginInstance) Module() *Module {
+	return &Module{inner: p.module}
 }
 
 // SetLogger sets a custom logging callback

--- a/extism.go
+++ b/extism.go
@@ -450,6 +450,7 @@ func (p *InstantiatedPlugin) Call(name string, data []byte) (uint32, []byte, err
 
 // Call a function by name with the given input and context, returning the output
 func (p *InstantiatedPlugin) CallWithContext(ctx context.Context, name string, data []byte) (uint32, []byte, error) {
+	ctx = context.WithValue(ctx, PluginCtxKey("extism"), p.extism)
 	if p.Timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, p.Timeout)

--- a/extism.go
+++ b/extism.go
@@ -338,8 +338,8 @@ func (m *Manifest) UnmarshalJSON(data []byte) error {
 }
 
 // Close closes the plugin by freeing the underlying resources.
-func (p *PluginInstance) Close() error {
-	return p.CloseWithContext(context.Background())
+func (p *PluginInstance) Close(ctx context.Context) error {
+	return p.CloseWithContext(ctx)
 }
 
 // CloseWithContext closes the plugin by freeing the underlying resources.

--- a/extism.go
+++ b/extism.go
@@ -133,6 +133,10 @@ func logStd(level LogLevel, message string) {
 	log.Print(message)
 }
 
+func (p *PluginInstance) Module() Module {
+	return Module{inner: p.module}
+}
+
 // SetLogger sets a custom logging callback
 func (p *PluginInstance) SetLogger(logger func(LogLevel, string)) {
 	p.log = logger

--- a/extism.go
+++ b/extism.go
@@ -105,8 +105,8 @@ func (l LogLevel) String() string {
 	return s
 }
 
-// InstantiatedPlugin is used to call WASM functions
-type InstantiatedPlugin struct {
+// Plugin is used to call WASM functions
+type Plugin struct {
 	close  []func(ctx context.Context) error
 	extism api.Module
 
@@ -134,16 +134,16 @@ func logStd(level LogLevel, message string) {
 	log.Print(message)
 }
 
-func (p *InstantiatedPlugin) Module() *Module {
+func (p *Plugin) Module() *Module {
 	return &Module{inner: p.module}
 }
 
 // SetLogger sets a custom logging callback
-func (p *InstantiatedPlugin) SetLogger(logger func(LogLevel, string)) {
+func (p *Plugin) SetLogger(logger func(LogLevel, string)) {
 	p.log = logger
 }
 
-func (p *InstantiatedPlugin) Log(level LogLevel, message string) {
+func (p *Plugin) Log(level LogLevel, message string) {
 	minimumLevel := LogLevel(pluginLogLevel.Load())
 
 	// If the global log level hasn't been set, use LogLevelOff as default
@@ -156,7 +156,7 @@ func (p *InstantiatedPlugin) Log(level LogLevel, message string) {
 	}
 }
 
-func (p *InstantiatedPlugin) Logf(level LogLevel, format string, args ...any) {
+func (p *Plugin) Logf(level LogLevel, format string, args ...any) {
 	message := fmt.Sprintf(format, args...)
 	p.Log(level, message)
 }
@@ -339,12 +339,12 @@ func (m *Manifest) UnmarshalJSON(data []byte) error {
 }
 
 // Close closes the plugin by freeing the underlying resources.
-func (p *InstantiatedPlugin) Close(ctx context.Context) error {
+func (p *Plugin) Close(ctx context.Context) error {
 	return p.CloseWithContext(ctx)
 }
 
 // CloseWithContext closes the plugin by freeing the underlying resources.
-func (p *InstantiatedPlugin) CloseWithContext(ctx context.Context) error {
+func (p *Plugin) CloseWithContext(ctx context.Context) error {
 	for _, fn := range p.close {
 		if err := fn(ctx); err != nil {
 			return err
@@ -362,12 +362,12 @@ func SetLogLevel(level LogLevel) {
 }
 
 // SetInput sets the input data for the plugin to be used in the next WebAssembly function call.
-func (p *InstantiatedPlugin) SetInput(data []byte) (uint64, error) {
+func (p *Plugin) SetInput(data []byte) (uint64, error) {
 	return p.SetInputWithContext(context.Background(), data)
 }
 
 // SetInputWithContext sets the input data for the plugin to be used in the next WebAssembly function call.
-func (p *InstantiatedPlugin) SetInputWithContext(ctx context.Context, data []byte) (uint64, error) {
+func (p *Plugin) SetInputWithContext(ctx context.Context, data []byte) (uint64, error) {
 	_, err := p.extism.ExportedFunction("reset").Call(ctx)
 	if err != nil {
 		fmt.Println(err)
@@ -384,12 +384,12 @@ func (p *InstantiatedPlugin) SetInputWithContext(ctx context.Context, data []byt
 }
 
 // GetOutput retrieves the output data from the last WebAssembly function call.
-func (p *InstantiatedPlugin) GetOutput() ([]byte, error) {
+func (p *Plugin) GetOutput() ([]byte, error) {
 	return p.GetOutputWithContext(context.Background())
 }
 
 // GetOutputWithContext retrieves the output data from the last WebAssembly function call.
-func (p *InstantiatedPlugin) GetOutputWithContext(ctx context.Context) ([]byte, error) {
+func (p *Plugin) GetOutputWithContext(ctx context.Context) ([]byte, error) {
 	outputOffs, err := p.extism.ExportedFunction("output_offset").Call(ctx)
 	if err != nil {
 		return []byte{}, err
@@ -409,17 +409,17 @@ func (p *InstantiatedPlugin) GetOutputWithContext(ctx context.Context) ([]byte, 
 }
 
 // Memory returns the plugin's WebAssembly memory interface.
-func (p *InstantiatedPlugin) Memory() api.Memory {
+func (p *Plugin) Memory() api.Memory {
 	return p.extism.ExportedMemory("memory")
 }
 
 // GetError retrieves the error message from the last WebAssembly function call, if any.
-func (p *InstantiatedPlugin) GetError() string {
+func (p *Plugin) GetError() string {
 	return p.GetErrorWithContext(context.Background())
 }
 
 // GetErrorWithContext retrieves the error message from the last WebAssembly function call.
-func (p *InstantiatedPlugin) GetErrorWithContext(ctx context.Context) string {
+func (p *Plugin) GetErrorWithContext(ctx context.Context) string {
 	errOffs, err := p.extism.ExportedFunction("error_get").Call(ctx)
 	if err != nil {
 		return ""
@@ -439,17 +439,17 @@ func (p *InstantiatedPlugin) GetErrorWithContext(ctx context.Context) string {
 }
 
 // FunctionExists returns true when the named function is present in the plugin's main Module
-func (p *InstantiatedPlugin) FunctionExists(name string) bool {
+func (p *Plugin) FunctionExists(name string) bool {
 	return p.module.ExportedFunction(name) != nil
 }
 
 // Call a function by name with the given input, returning the output
-func (p *InstantiatedPlugin) Call(name string, data []byte) (uint32, []byte, error) {
+func (p *Plugin) Call(name string, data []byte) (uint32, []byte, error) {
 	return p.CallWithContext(context.Background(), name, data)
 }
 
 // Call a function by name with the given input and context, returning the output
-func (p *InstantiatedPlugin) CallWithContext(ctx context.Context, name string, data []byte) (uint32, []byte, error) {
+func (p *Plugin) CallWithContext(ctx context.Context, name string, data []byte) (uint32, []byte, error) {
 	ctx = context.WithValue(ctx, PluginCtxKey("extism"), p.extism)
 	if p.Timeout > 0 {
 		var cancel context.CancelFunc

--- a/extism.go
+++ b/extism.go
@@ -13,14 +13,12 @@ import (
 	"math"
 	"net/http"
 	"os"
-	"strings"
 	"sync/atomic"
 	"time"
 
 	observe "github.com/dylibso/observe-sdk/go"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	"github.com/tetratelabs/wazero/sys"
 )
 
@@ -45,14 +43,9 @@ type Runtime struct {
 	hasWasi bool
 }
 
-// PluginConfig contains configuration options for the Extism plugin.
-type PluginConfig struct {
-	ModuleConfig              wazero.ModuleConfig
-	RuntimeConfig             wazero.RuntimeConfig
-	EnableWasi                bool
-	ObserveAdapter            *observe.AdapterBase
-	ObserveOptions            *observe.Options
-	EnableHttpResponseHeaders bool
+// PluginInstanceConfig contains configuration options for the Extism plugin.
+type PluginInstanceConfig struct {
+	ModuleConfig wazero.ModuleConfig
 }
 
 // HttpRequest represents an HTTP request to be made by the plugin.
@@ -112,11 +105,14 @@ func (l LogLevel) String() string {
 	return s
 }
 
-// Plugin is used to call WASM functions
-type Plugin struct {
-	Runtime *Runtime
-	Modules map[string]Module
-	Main    Module
+// PluginInstance is used to call WASM functions
+type PluginInstance struct {
+	close  []func(ctx context.Context) error
+	plugin *Plugin
+
+	//Runtime *Runtime
+	//Main    Module
+	module  api.Module
 	Timeout time.Duration
 	Config  map[string]string
 	// NOTE: maybe we can have some nice methods for getting/setting vars
@@ -138,11 +134,11 @@ func logStd(level LogLevel, message string) {
 }
 
 // SetLogger sets a custom logging callback
-func (p *Plugin) SetLogger(logger func(LogLevel, string)) {
+func (p *PluginInstance) SetLogger(logger func(LogLevel, string)) {
 	p.log = logger
 }
 
-func (p *Plugin) Log(level LogLevel, message string) {
+func (p *PluginInstance) Log(level LogLevel, message string) {
 	minimumLevel := LogLevel(pluginLogLevel.Load())
 
 	// If the global log level hasn't been set, use LogLevelOff as default
@@ -155,7 +151,7 @@ func (p *Plugin) Log(level LogLevel, message string) {
 	}
 }
 
-func (p *Plugin) Logf(level LogLevel, format string, args ...any) {
+func (p *PluginInstance) Logf(level LogLevel, format string, args ...any) {
 	message := fmt.Sprintf(format, args...)
 	p.Log(level, message)
 }
@@ -338,13 +334,18 @@ func (m *Manifest) UnmarshalJSON(data []byte) error {
 }
 
 // Close closes the plugin by freeing the underlying resources.
-func (p *Plugin) Close() error {
+func (p *PluginInstance) Close() error {
 	return p.CloseWithContext(context.Background())
 }
 
 // CloseWithContext closes the plugin by freeing the underlying resources.
-func (p *Plugin) CloseWithContext(ctx context.Context) error {
-	return p.Runtime.Wazero.Close(ctx)
+func (p *PluginInstance) CloseWithContext(ctx context.Context) error {
+	for _, fn := range p.close {
+		if err := fn(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // add an atomic global to store the plugin runtime-wide log level
@@ -355,235 +356,45 @@ func SetLogLevel(level LogLevel) {
 	pluginLogLevel.Store(int32(level))
 }
 
-// NewPlugin creates a new Extism plugin with the given manifest, configuration, and host functions.
-// The returned plugin can be used to call WebAssembly functions and interact with the plugin.
-func NewPlugin(
-	ctx context.Context,
-	manifest Manifest,
-	config PluginConfig,
-	functions []HostFunction) (*Plugin, error) {
-	var rconfig wazero.RuntimeConfig
-	if config.RuntimeConfig == nil {
-		rconfig = wazero.NewRuntimeConfig()
-	} else {
-		rconfig = config.RuntimeConfig
-	}
-
-	// Make sure function calls are cancelled if the context is cancelled
-	if manifest.Timeout > 0 {
-		rconfig = rconfig.WithCloseOnContextDone(true)
-	}
-
-	if manifest.Memory != nil {
-		if manifest.Memory.MaxPages > 0 {
-			rconfig = rconfig.WithMemoryLimitPages(manifest.Memory.MaxPages)
-		}
-	}
-
-	rt := wazero.NewRuntimeWithConfig(ctx, rconfig)
-
-	extism, err := rt.InstantiateWithConfig(ctx, extismRuntimeWasm, wazero.NewModuleConfig().WithName("extism"))
-	if err != nil {
-		return nil, err
-	}
-
-	hostModules := make(map[string][]HostFunction, 0)
-	for _, f := range functions {
-		hostModules[f.Namespace] = append(hostModules[f.Namespace], f)
-	}
-
-	env, err := buildEnvModule(ctx, rt, extism)
-	if err != nil {
-		return nil, err
-	}
-
-	c := Runtime{
-		Wazero: rt,
-		Extism: extism,
-		Env:    env,
-	}
-
-	if config.EnableWasi {
-		wasi_snapshot_preview1.MustInstantiate(ctx, c.Wazero)
-
-		c.hasWasi = true
-	}
-
-	for name, funcs := range hostModules {
-		_, err := buildHostModule(ctx, c.Wazero, name, funcs)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	count := len(manifest.Wasm)
-	if count == 0 {
-		return nil, fmt.Errorf("manifest can't be empty")
-	}
-
-	modules := map[string]Module{}
-
-	// NOTE: this is only necessary for guest modules because
-	// host modules have the same access privileges as the host itself
-	fs := wazero.NewFSConfig()
-
-	for host, guest := range manifest.AllowedPaths {
-		if strings.HasPrefix(host, "ro:") {
-			trimmed := strings.TrimPrefix(host, "ro:")
-			fs = fs.WithReadOnlyDirMount(trimmed, guest)
-		} else {
-			fs = fs.WithDirMount(host, guest)
-		}
-	}
-
-	moduleConfig := config.ModuleConfig
-	if moduleConfig == nil {
-		moduleConfig = wazero.NewModuleConfig()
-	}
-
-	// NOTE: we don't want wazero to call the start function, we will initialize
-	// the guest runtime manually.
-	// See: https://github.com/extism/go-sdk/pull/1#issuecomment-1650527495
-	moduleConfig = moduleConfig.WithStartFunctions().WithFSConfig(fs)
-
-	_, wasiOutput := os.LookupEnv("EXTISM_ENABLE_WASI_OUTPUT")
-	if c.hasWasi && wasiOutput {
-		moduleConfig = moduleConfig.WithStderr(os.Stderr).WithStdout(os.Stdout)
-	}
-
-	// Try to find the main module:
-	//  - There is always one main module
-	//  - If a Wasm value has the Name field set to "main" then use that module
-	//  - If there is only one module in the manifest then that is the main module by default
-	//  - Otherwise the last module listed is the main module
-
-	var trace *observe.TraceCtx
-	for i, wasm := range manifest.Wasm {
-		data, err := wasm.ToWasmData(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		_, mainExists := modules["main"]
-		if data.Name == "" || i == len(manifest.Wasm)-1 && !mainExists {
-			data.Name = "main"
-		}
-
-		if data.Name == "main" && config.ObserveAdapter != nil {
-			trace, err = config.ObserveAdapter.NewTraceCtx(ctx, c.Wazero, data.Data, config.ObserveOptions)
-			if err != nil {
-				return nil, fmt.Errorf("failed to initialize Observe Adapter: %v", err)
-			}
-
-			trace.Finish()
-		}
-
-		_, okh := hostModules[data.Name]
-		_, okm := modules[data.Name]
-
-		if data.Name == "extism:host/env" || okh || okm {
-			return nil, fmt.Errorf("module name collision: '%s'", data.Name)
-		}
-
-		if data.Hash != "" {
-			calculatedHash := calculateHash(data.Data)
-			if data.Hash != calculatedHash {
-				return nil, fmt.Errorf("hash mismatch for module '%s'", data.Name)
-			}
-		}
-
-		m, err := c.Wazero.InstantiateWithConfig(ctx, data.Data, moduleConfig.WithName(data.Name))
-		if err != nil {
-			return nil, err
-		}
-
-		modules[data.Name] = Module{inner: m}
-	}
-
-	i := 0
-	httpMax := int64(1024 * 1024 * 50)
-	if manifest.Memory != nil && manifest.Memory.MaxHttpResponseBytes >= 0 {
-		httpMax = int64(manifest.Memory.MaxHttpResponseBytes)
-	}
-
-	varMax := int64(1024 * 1024)
-	if manifest.Memory != nil && manifest.Memory.MaxVarBytes >= 0 {
-		varMax = int64(manifest.Memory.MaxVarBytes)
-	}
-
-	var headers map[string]string = nil
-	if config.EnableHttpResponseHeaders {
-		headers = map[string]string{}
-	}
-	for _, m := range modules {
-		if m.inner.Name() == "main" {
-			p := &Plugin{
-				Runtime:              &c,
-				Modules:              modules,
-				Main:                 m,
-				Config:               manifest.Config,
-				Var:                  map[string][]byte{},
-				AllowedHosts:         manifest.AllowedHosts,
-				AllowedPaths:         manifest.AllowedPaths,
-				LastStatusCode:       0,
-				LastResponseHeaders:  headers,
-				Timeout:              time.Duration(manifest.Timeout) * time.Millisecond,
-				MaxHttpResponseBytes: httpMax,
-				MaxVarBytes:          varMax,
-				log:                  logStd,
-				Adapter:              config.ObserveAdapter,
-				TraceCtx:             trace,
-			}
-
-			p.guestRuntime = detectGuestRuntime(ctx, p)
-			return p, nil
-		}
-
-		i++
-	}
-
-	return nil, errors.New("no main module found")
-}
-
 // SetInput sets the input data for the plugin to be used in the next WebAssembly function call.
-func (plugin *Plugin) SetInput(data []byte) (uint64, error) {
-	return plugin.SetInputWithContext(context.Background(), data)
+func (p *PluginInstance) SetInput(data []byte) (uint64, error) {
+	return p.SetInputWithContext(context.Background(), data)
 }
 
 // SetInputWithContext sets the input data for the plugin to be used in the next WebAssembly function call.
-func (plugin *Plugin) SetInputWithContext(ctx context.Context, data []byte) (uint64, error) {
-	_, err := plugin.Runtime.Extism.ExportedFunction("reset").Call(ctx)
+func (p *PluginInstance) SetInputWithContext(ctx context.Context, data []byte) (uint64, error) {
+	_, err := p.plugin.extism.ExportedFunction("reset").Call(ctx)
 	if err != nil {
 		fmt.Println(err)
 		return 0, errors.New("reset")
 	}
 
-	ptr, err := plugin.Runtime.Extism.ExportedFunction("alloc").Call(ctx, uint64(len(data)))
+	ptr, err := p.plugin.extism.ExportedFunction("alloc").Call(ctx, uint64(len(data)))
 	if err != nil {
 		return 0, err
 	}
-	plugin.Memory().Write(uint32(ptr[0]), data)
-	plugin.Runtime.Extism.ExportedFunction("input_set").Call(ctx, ptr[0], uint64(len(data)))
+	p.Memory().Write(uint32(ptr[0]), data)
+	p.plugin.extism.ExportedFunction("input_set").Call(ctx, ptr[0], uint64(len(data)))
 	return ptr[0], nil
 }
 
 // GetOutput retrieves the output data from the last WebAssembly function call.
-func (plugin *Plugin) GetOutput() ([]byte, error) {
-	return plugin.GetOutputWithContext(context.Background())
+func (p *PluginInstance) GetOutput() ([]byte, error) {
+	return p.GetOutputWithContext(context.Background())
 }
 
 // GetOutputWithContext retrieves the output data from the last WebAssembly function call.
-func (plugin *Plugin) GetOutputWithContext(ctx context.Context) ([]byte, error) {
-	outputOffs, err := plugin.Runtime.Extism.ExportedFunction("output_offset").Call(ctx)
+func (p *PluginInstance) GetOutputWithContext(ctx context.Context) ([]byte, error) {
+	outputOffs, err := p.plugin.extism.ExportedFunction("output_offset").Call(ctx)
 	if err != nil {
 		return []byte{}, err
 	}
 
-	outputLen, err := plugin.Runtime.Extism.ExportedFunction("output_length").Call(ctx)
+	outputLen, err := p.plugin.extism.ExportedFunction("output_length").Call(ctx)
 	if err != nil {
 		return []byte{}, err
 	}
-	mem, _ := plugin.Memory().Read(uint32(outputOffs[0]), uint32(outputLen[0]))
+	mem, _ := p.Memory().Read(uint32(outputOffs[0]), uint32(outputLen[0]))
 
 	// Make sure output is copied, because `Read` returns a write-through view
 	buffer := make([]byte, len(mem))
@@ -593,18 +404,18 @@ func (plugin *Plugin) GetOutputWithContext(ctx context.Context) ([]byte, error) 
 }
 
 // Memory returns the plugin's WebAssembly memory interface.
-func (plugin *Plugin) Memory() api.Memory {
-	return plugin.Runtime.Extism.ExportedMemory("memory")
+func (p *PluginInstance) Memory() api.Memory {
+	return p.plugin.extism.ExportedMemory("memory")
 }
 
 // GetError retrieves the error message from the last WebAssembly function call, if any.
-func (plugin *Plugin) GetError() string {
-	return plugin.GetErrorWithContext(context.Background())
+func (p *PluginInstance) GetError() string {
+	return p.GetErrorWithContext(context.Background())
 }
 
 // GetErrorWithContext retrieves the error message from the last WebAssembly function call.
-func (plugin *Plugin) GetErrorWithContext(ctx context.Context) string {
-	errOffs, err := plugin.Runtime.Extism.ExportedFunction("error_get").Call(ctx)
+func (p *PluginInstance) GetErrorWithContext(ctx context.Context) string {
+	errOffs, err := p.plugin.extism.ExportedFunction("error_get").Call(ctx)
 	if err != nil {
 		return ""
 	}
@@ -613,43 +424,43 @@ func (plugin *Plugin) GetErrorWithContext(ctx context.Context) string {
 		return ""
 	}
 
-	errLen, err := plugin.Runtime.Extism.ExportedFunction("length").Call(ctx, errOffs[0])
+	errLen, err := p.plugin.extism.ExportedFunction("length").Call(ctx, errOffs[0])
 	if err != nil {
 		return ""
 	}
 
-	mem, _ := plugin.Memory().Read(uint32(errOffs[0]), uint32(errLen[0]))
+	mem, _ := p.Memory().Read(uint32(errOffs[0]), uint32(errLen[0]))
 	return string(mem)
 }
 
 // FunctionExists returns true when the named function is present in the plugin's main Module
-func (plugin *Plugin) FunctionExists(name string) bool {
-	return plugin.Main.inner.ExportedFunction(name) != nil
+func (p *PluginInstance) FunctionExists(name string) bool {
+	return p.module.ExportedFunction(name) != nil
 }
 
 // Call a function by name with the given input, returning the output
-func (plugin *Plugin) Call(name string, data []byte) (uint32, []byte, error) {
-	return plugin.CallWithContext(context.Background(), name, data)
+func (p *PluginInstance) Call(name string, data []byte) (uint32, []byte, error) {
+	return p.CallWithContext(context.Background(), name, data)
 }
 
 // Call a function by name with the given input and context, returning the output
-func (plugin *Plugin) CallWithContext(ctx context.Context, name string, data []byte) (uint32, []byte, error) {
-	if plugin.Timeout > 0 {
+func (p *PluginInstance) CallWithContext(ctx context.Context, name string, data []byte) (uint32, []byte, error) {
+	if p.Timeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, plugin.Timeout)
+		ctx, cancel = context.WithTimeout(ctx, p.Timeout)
 		defer cancel()
 	}
 
-	ctx = context.WithValue(ctx, PluginCtxKey("plugin"), plugin)
+	ctx = context.WithValue(ctx, PluginCtxKey("plugin"), p)
 
-	intputOffset, err := plugin.SetInput(data)
+	intputOffset, err := p.SetInput(data)
 	if err != nil {
 		return 1, []byte{}, err
 	}
 
 	ctx = context.WithValue(ctx, InputOffsetKey("inputOffset"), intputOffset)
 
-	var f = plugin.Main.inner.ExportedFunction(name)
+	var f = p.module.ExportedFunction(name)
 
 	if f == nil {
 		return 1, []byte{}, fmt.Errorf("unknown function: %s", name)
@@ -658,20 +469,20 @@ func (plugin *Plugin) CallWithContext(ctx context.Context, name string, data []b
 	}
 
 	var isStart = name == "_start"
-	if plugin.guestRuntime.init != nil && !isStart && !plugin.guestRuntime.initialized {
-		err := plugin.guestRuntime.init(ctx)
+	if p.guestRuntime.init != nil && !isStart && !p.guestRuntime.initialized {
+		err := p.guestRuntime.init(ctx)
 		if err != nil {
 			return 1, []byte{}, fmt.Errorf("failed to initialize runtime: %v", err)
 		}
-		plugin.guestRuntime.initialized = true
+		p.guestRuntime.initialized = true
 	}
 
-	plugin.Logf(LogLevelDebug, "Calling function : %v", name)
+	p.Logf(LogLevelDebug, "Calling function : %v", name)
 
 	res, err := f.Call(ctx)
 
-	if plugin.TraceCtx != nil {
-		defer plugin.TraceCtx.Finish()
+	if p.TraceCtx != nil {
+		defer p.TraceCtx.Finish()
 	}
 
 	// Try to extact WASI exit code
@@ -679,6 +490,11 @@ func (plugin *Plugin) CallWithContext(ctx context.Context, name string, data []b
 		exitCode := exitErr.ExitCode()
 
 		if exitCode == 0 {
+			// It's possible for the function to return 0 as an error code, even
+			// if the module is closed.
+			if p.module.IsClosed() {
+				return 0, nil, fmt.Errorf("module is closed")
+			}
 			err = nil
 		}
 
@@ -704,14 +520,14 @@ func (plugin *Plugin) CallWithContext(ctx context.Context, name string, data []b
 	}
 
 	if rc != 0 {
-		errMsg := plugin.GetError()
+		errMsg := p.GetError()
 		if errMsg == "" {
-			errMsg = "encountered an unknown error in call to Extism plugin function " + name
+			errMsg = "encountered an unknown error in call to Extism p function " + name
 		}
 		return rc, []byte{}, errors.New(errMsg)
 	}
 
-	output, err := plugin.GetOutput()
+	output, err := p.GetOutput()
 	if err != nil {
 		return rc, []byte{}, fmt.Errorf("failed to get output: %v", err)
 	}

--- a/extism_test.go
+++ b/extism_test.go
@@ -5,11 +5,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	observe "github.com/dylibso/observe-sdk/go"
+	"github.com/dylibso/observe-sdk/go/adapter/stdout"
 	"github.com/stretchr/testify/assert"
 	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/experimental"
+	"github.com/tetratelabs/wazero/experimental/logging"
+	"github.com/tetratelabs/wazero/sys"
 	"log"
 	"os"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestWasmUrl(t *testing.T) {
@@ -59,7 +66,7 @@ func TestFunctionExsits(t *testing.T) {
 	manifest := manifest("alloc.wasm")
 
 	if plugin, ok := plugin(t, manifest); ok {
-		defer plugin.Close()
+		defer plugin.Close(context.Background())
 
 		assert.True(t, plugin.FunctionExists("run_test"))
 		assert.False(t, plugin.FunctionExists("i_dont_exist"))
@@ -70,7 +77,7 @@ func TestFailOnUnknownFunction(t *testing.T) {
 	manifest := manifest("alloc.wasm")
 
 	if plugin, ok := plugin(t, manifest); ok {
-		defer plugin.Close()
+		defer plugin.Close(context.Background())
 
 		_, _, err := plugin.Call("i_dont_exist", []byte{})
 		assert.NotNil(t, err, "Call to unknwon function must fail")
@@ -81,7 +88,7 @@ func TestCallFunction(t *testing.T) {
 	manifest := manifest("count_vowels.wasm")
 
 	if plugin, ok := plugin(t, manifest); ok {
-		defer plugin.Close()
+		defer plugin.Close(context.Background())
 
 		cases := map[string]int{
 			"hello world": 3,
@@ -111,7 +118,7 @@ func TestClosePlugin(t *testing.T) {
 		exit, _, err := plugin.Call("run_test", []byte{})
 		assertCall(t, err, exit)
 
-		err = plugin.Close()
+		err = plugin.Close(context.Background())
 		if err != nil {
 			t.Errorf("Close must not return an error: %v", err)
 		}
@@ -125,7 +132,7 @@ func TestAlloc(t *testing.T) {
 	manifest := manifest("alloc.wasm")
 
 	if plugin, ok := plugin(t, manifest); ok {
-		defer plugin.Close()
+		defer plugin.Close(context.Background())
 
 		exit, _, err := plugin.Call("run_test", []byte{})
 
@@ -148,7 +155,7 @@ func TestConfig(t *testing.T) {
 		}
 
 		if plugin, ok := plugin(t, manifest); ok {
-			defer plugin.Close()
+			defer plugin.Close(context.Background())
 
 			exit, output, err := plugin.Call("run_test", []byte{})
 
@@ -166,7 +173,7 @@ func TestFail(t *testing.T) {
 	manifest := manifest("fail.wasm")
 
 	if plugin, ok := plugin(t, manifest); ok {
-		defer plugin.Close()
+		defer plugin.Close(context.Background())
 
 		exit, _, err := plugin.Call("run_test", []byte{})
 
@@ -179,7 +186,7 @@ func TestHello(t *testing.T) {
 	manifest := manifest("hello.wasm")
 
 	if plugin, ok := plugin(t, manifest); ok {
-		defer plugin.Close()
+		defer plugin.Close(context.Background())
 
 		exit, output, err := plugin.Call("run_test", []byte{})
 
@@ -204,7 +211,7 @@ func TestExit(t *testing.T) {
 		manifest := manifest("exit.wasm")
 
 		if plugin, ok := plugin(t, manifest); ok {
-			defer plugin.Close()
+			defer plugin.Close(context.Background())
 
 			if config != "" {
 				plugin.Config["code"] = config
@@ -237,7 +244,7 @@ func TestHost_simple(t *testing.T) {
 	)
 
 	if plugin, ok := plugin(t, manifest, mult); ok {
-		defer plugin.Close()
+		defer plugin.Close(context.Background())
 
 		exit, output, err := plugin.Call("run_test", []byte{})
 
@@ -281,7 +288,7 @@ func TestHost_memory(t *testing.T) {
 	mult.SetNamespace("host")
 
 	if plugin, ok := plugin(t, manifest, mult); ok {
-		defer plugin.Close()
+		defer plugin.Close(context.Background())
 
 		exit, output, err := plugin.Call("run_test", []byte("Frodo"))
 
@@ -386,7 +393,7 @@ func TestHTTP_allowed(t *testing.T) {
 	manifest.AllowedHosts = []string{"jsonplaceholder.*.com"}
 
 	if plugin, ok := plugin(t, manifest); ok {
-		defer plugin.Close()
+		defer plugin.Close(context.Background())
 
 		exit, output, err := plugin.Call("run_test", []byte{})
 
@@ -417,7 +424,7 @@ func TestHTTP_denied(t *testing.T) {
 		}
 
 		if plugin, ok := plugin(t, manifest); ok {
-			defer plugin.Close()
+			defer plugin.Close(context.Background())
 
 			exit, _, err := plugin.Call("run_test", []byte{})
 
@@ -493,7 +500,7 @@ func TestLog_default(t *testing.T) {
 	}()
 
 	if plugin, ok := plugin(t, manifest); ok {
-		defer plugin.Close()
+		defer plugin.Close(context.Background())
 
 		SetLogLevel(LogLevelWarn) // Only warn and error logs should be printed to the console
 		exit, _, err := plugin.Call("run_test", []byte{})
@@ -509,572 +516,613 @@ func TestLog_default(t *testing.T) {
 	}
 }
 
-//func TestLog_custom(t *testing.T) {
-//	manifest := manifest("log.wasm")
-//
-//	type LogEntry struct {
-//		message string
-//		level   LogLevel
-//	}
-//
-//	if plugin, ok := plugin(t, manifest); ok {
-//		defer plugin.Close()
-//
-//		var actual strings.Builder
-//
-//		var fmtLogMessage = func(level LogLevel, message string) string {
-//			return fmt.Sprintf("%s: %s\n", level.String(), message)
-//		}
-//
-//		plugin.SetLogger(func(level LogLevel, message string) {
-//			actual.WriteString(fmtLogMessage(level, message))
-//			switch level {
-//			case LogLevelDebug:
-//				assert.Equal(t, level.String(), "DEBUG")
-//			case LogLevelInfo:
-//				assert.Equal(t, level.String(), "INFO")
-//			case LogLevelWarn:
-//				assert.Equal(t, level.String(), "WARN")
-//			case LogLevelError:
-//				assert.Equal(t, level.String(), "ERROR")
-//			case LogLevelTrace:
-//				assert.Equal(t, level.String(), "TRACE")
-//			}
-//		})
-//
-//		SetLogLevel(LogLevelTrace)
-//
-//		exit, _, err := plugin.Call("run_test", []byte{})
-//
-//		if assertCall(t, err, exit) {
-//			expected := []LogEntry{
-//				{message: "this is a trace log", level: LogLevelTrace},
-//				{message: "this is a debug log", level: LogLevelDebug},
-//				{message: "this is an info log", level: LogLevelInfo},
-//				{message: "this is a warning log", level: LogLevelWarn},
-//				{message: "this is an error log", level: LogLevelError},
-//			}
-//			actualLogs := actual.String()
-//			for _, log := range expected {
-//				assert.Contains(t, actualLogs, fmtLogMessage(log.level, log.message))
-//			}
-//		}
-//
-//		SetLogLevel(LogLevelWarn)
-//		actual.Reset()
-//
-//		exit, _, err = plugin.Call("run_test", []byte{})
-//
-//		if assertCall(t, err, exit) {
-//			expected := []LogEntry{
-//				{message: "this is a warning log", level: LogLevelWarn},
-//				{message: "this is an error log", level: LogLevelError},
-//			}
-//			expectedNot := []LogEntry{
-//				{message: "this is a trace log", level: LogLevelTrace},
-//				{message: "this is a debug log", level: LogLevelDebug},
-//				{message: "this is an info log", level: LogLevelInfo},
-//			}
-//			actualLogs := actual.String()
-//			for _, log := range expected {
-//				assert.Contains(t, actualLogs, fmtLogMessage(log.level, log.message))
-//			}
-//			for _, log := range expectedNot {
-//				assert.NotContains(t, actualLogs, fmtLogMessage(log.level, log.message))
-//			}
-//		}
-//	}
-//}
-//
-//func TestTimeout(t *testing.T) {
-//	manifest := manifest("sleep.wasm")
-//	manifest.Timeout = 100            // 100ms
-//	manifest.Config["duration"] = "3" // sleep for 3 seconds
-//
-//	config := PluginInstanceConfig{
-//		ModuleConfig: wazero.NewModuleConfig().WithSysWalltime(),
-//		EnableWasi:   true,
-//	}
-//
-//	plugin, err := NewPlugin(context.Background(), manifest, config, []HostFunction{})
-//
-//	if err != nil {
-//		t.Errorf("Could not create plugin: %v", err)
-//	}
-//
-//	defer plugin.Close()
-//
-//	exit, _, err := plugin.Call("run_test", []byte{})
-//
-//	assert.Equal(t, sys.ExitCodeDeadlineExceeded, exit, "Exit code must be `sys.ExitCodeDeadlineExceeded`")
-//	assert.Equal(t, "module closed with context deadline exceeded", err.Error())
-//}
-//
-//func TestCancel(t *testing.T) {
-//	manifest := manifest("sleep.wasm")
-//	manifest.Config["duration"] = "3" // sleep for 3 seconds
-//
-//	ctx := context.Background()
-//	config := PluginInstanceConfig{
-//		ModuleConfig:  wazero.NewModuleConfig().WithSysWalltime(),
-//		EnableWasi:    true,
-//		RuntimeConfig: wazero.NewRuntimeConfig().WithCloseOnContextDone(true),
-//	}
-//
-//	plugin, err := NewPlugin(ctx, manifest, config, []HostFunction{})
-//
-//	if err != nil {
-//		t.Errorf("Could not create plugin: %v", err)
-//	}
-//
-//	defer plugin.Close()
-//
-//	ctx, cancel := context.WithCancel(context.Background())
-//	go func() {
-//		time.Sleep(100 * time.Millisecond)
-//		cancel()
-//	}()
-//
-//	exit, _, err := plugin.CallWithContext(ctx, "run_test", []byte{})
-//
-//	assert.Equal(t, sys.ExitCodeContextCanceled, exit, "Exit code must be `sys.ExitCodeContextCanceled`")
-//	assert.Equal(t, "module closed with context canceled", err.Error())
-//}
-//
-//func TestVar(t *testing.T) {
-//	manifest := manifest("var.wasm")
-//
-//	if plugin, ok := plugin(t, manifest); ok {
-//		defer plugin.Close()
-//
-//		plugin.Var["a"] = uintToLEBytes(10)
-//
-//		exit, _, err := plugin.Call("run_test", []byte{})
-//
-//		if assertCall(t, err, exit) {
-//			actual := uintFromLEBytes(plugin.Var["a"])
-//			expected := uint(20)
-//
-//			assert.Equal(t, expected, actual)
-//		}
-//
-//		exit, _, err = plugin.Call("run_test", []byte{})
-//
-//		if assertCall(t, err, exit) {
-//			actual := uintFromLEBytes(plugin.Var["a"])
-//			expected := uint(40)
-//
-//			assert.Equal(t, expected, actual)
-//		}
-//	}
-//
-//}
-//
-//func TestNoVars(t *testing.T) {
-//	manifest := manifest("var.wasm")
-//	manifest.Memory = &ManifestMemory{MaxVarBytes: 0}
-//
-//	if plugin, ok := plugin(t, manifest); ok {
-//		defer plugin.Close()
-//
-//		plugin.Var["a"] = uintToLEBytes(10)
-//
-//		_, _, err := plugin.Call("run_test", []byte{})
-//
-//		if err == nil {
-//			t.Fail()
-//		}
-//	}
-//
-//}
-//
-//func TestFS(t *testing.T) {
-//	manifest := manifest("fs.wasm")
-//	manifest.AllowedPaths = map[string]string{
-//		"testdata": "/mnt",
-//	}
-//
-//	if plugin, ok := plugin(t, manifest); ok {
-//		defer plugin.Close()
-//
-//		exit, output, err := plugin.Call("run_test", []byte{})
-//
-//		if assertCall(t, err, exit) {
-//			actual := string(output)
-//			expected := "hello world!"
-//
-//			assert.Equal(t, expected, actual)
-//		}
-//	}
-//}
-//
-//func TestReadOnlyMount(t *testing.T) {
-//	manifest := manifest("read_write.wasm")
-//	manifest.AllowedPaths = map[string]string{
-//		"ro:testdata": "/mnt",
-//	}
-//
-//	if plugin, ok := plugin(t, manifest); ok {
-//		defer plugin.Close()
-//		plugin.Config["path"] = "/mnt/test.txt"
-//
-//		exit, output, err := plugin.Call("try_read", []byte{})
-//
-//		if assertCall(t, err, exit) {
-//			actual := string(output)
-//			expected := "hello world!"
-//
-//			assert.Equal(t, expected, actual)
-//		}
-//
-//		_, _, err = plugin.Call("try_write", []byte("hello hello!"))
-//
-//		assert.NotNil(t, err, "Write must fail")
-//		assert.Contains(t, err.Error(), "Failed to write file")
-//	}
-//}
-//
-//func TestCountVowels(t *testing.T) {
-//	manifest := manifest("count_vowels.wasm")
-//
-//	if plugin, ok := plugin(t, manifest); ok {
-//		defer plugin.Close()
-//
-//		exit, output, err := plugin.Call("count_vowels", []byte("hello world"))
-//
-//		if assertCall(t, err, exit) {
-//			expected := 3 // 3 vowels
-//
-//			var actual map[string]int
-//			json.Unmarshal(output, &actual)
-//
-//			assert.Equal(t, expected, actual["count"])
-//		}
-//	}
-//}
-//
-//func TestMultipleCallsOutput(t *testing.T) {
-//	manifest := manifest("count_vowels.wasm")
-//
-//	if plugin, ok := plugin(t, manifest); ok {
-//		defer plugin.Close()
-//
-//		exit, output1, err := plugin.Call("count_vowels", []byte("aaa"))
-//
-//		if !assertCall(t, err, exit) {
-//			return
-//		}
-//
-//		exit, output2, err := plugin.Call("count_vowels", []byte("bbba"))
-//
-//		if !assertCall(t, err, exit) {
-//			return
-//		}
-//
-//		assert.Equal(t, `{"count":3,"total":3,"vowels":"aeiouAEIOU"}`, string(output1))
-//		assert.Equal(t, `{"count":1,"total":4,"vowels":"aeiouAEIOU"}`, string(output2))
-//	}
-//}
-//
-//func TestHelloHaskell(t *testing.T) {
-//	var buf bytes.Buffer
-//	log.SetOutput(&buf)
-//	defer func() {
-//		log.SetOutput(os.Stderr)
-//	}()
-//
-//	manifest := manifest("hello_haskell.wasm")
-//
-//	if plugin, ok := plugin(t, manifest); ok {
-//		defer plugin.Close()
-//
-//		SetLogLevel(LogLevelTrace)
-//		plugin.Config["greeting"] = "Howdy"
-//
-//		exit, output, err := plugin.Call("testing", []byte("John"))
-//
-//		if assertCall(t, err, exit) {
-//			actual := string(output)
-//			expected := "Howdy, John"
-//
-//			assert.Equal(t, expected, actual)
-//
-//			logs := buf.String()
-//
-//			assert.Contains(t, logs, "Initialized Haskell language runtime.")
-//		}
-//	}
-//}
-//
-//func TestJsonManifest(t *testing.T) {
-//	m := `
-//	{
-//		"wasm": [
-//		  {
-//			"path": "wasm/sleep.wasm"
-//		  }
-//		],
-//		"memory": {
-//		  "max_pages": 100
-//		},
-//		"config": {
-//		  "key1": "value1",
-//		  "key2": "value2",
-//		  "duration": "3"
-//		},
-//		"timeout_ms": 100
-//	}
-//	`
-//
-//	manifest := Manifest{}
-//	err := manifest.UnmarshalJSON([]byte(m))
-//	if err != nil {
-//		t.Error(err)
-//	}
-//
-//	if plugin, ok := plugin(t, manifest); ok {
-//		defer plugin.Close()
-//
-//		exit, _, err := plugin.Call("run_test", []byte{})
-//
-//		assert.Equal(t, sys.ExitCodeDeadlineExceeded, exit, "Exit code must be `sys.ExitCodeDeadlineExceeded`")
-//		assert.Equal(t, "module closed with context deadline exceeded", err.Error())
-//	}
-//}
-//
-//func TestInputOffset(t *testing.T) {
-//	manifest := manifest("input_offset.wasm")
-//
-//	if plugin, ok := plugin(t, manifest); ok {
-//		defer plugin.Close()
-//
-//		input_data := []byte("hello world")
-//		exit, output, err := plugin.Call("input_offset_length", input_data)
-//
-//		if assertCall(t, err, exit) {
-//			assert.Equal(t, len(input_data), int(output[0]))
-//		}
-//	}
-//}
-//
-//func TestObserve(t *testing.T) {
-//	ctx := context.Background()
-//
-//	var buf bytes.Buffer
-//	log.SetOutput(&buf)
-//
-//	adapter := stdout.NewStdoutAdapter()
-//	adapter.Start(ctx)
-//
-//	manifest := manifest("nested.c.instr.wasm")
-//
-//	config := PluginInstanceConfig{
-//		ModuleConfig:   wazero.NewModuleConfig().WithSysWalltime(),
-//		EnableWasi:     true,
-//		ObserveAdapter: adapter.AdapterBase,
-//		ObserveOptions: &observe.Options{
-//			SpanFilter:        &observe.SpanFilter{MinDuration: 1 * time.Nanosecond},
-//			ChannelBufferSize: 1024,
-//		},
-//	}
-//
-//	// PluginInstance 1
-//	plugin, err := NewPlugin(ctx, manifest, config, []HostFunction{})
-//	if err != nil {
-//		panic(err)
-//	}
-//
-//	meta := map[string]string{
-//		"http.url":         "https://example.com/my-endpoint",
-//		"http.status_code": "200",
-//		"http.client_ip":   "192.168.1.0",
-//	}
-//
-//	plugin.TraceCtx.Metadata(meta)
-//
-//	_, _, _ = plugin.Call("_start", []byte("hello world"))
-//	plugin.Close()
-//
-//	// HACK: make sure we give enough time for the events to get flushed
-//	time.Sleep(100 * time.Millisecond)
-//
-//	actual := buf.String()
-//	assert.Contains(t, actual, "  Call to _start took")
-//	assert.Contains(t, actual, "      Call to main took")
-//	assert.Contains(t, actual, "        Call to one took")
-//	assert.Contains(t, actual, "          Call to two took")
-//	assert.Contains(t, actual, "            Call to three took")
-//	assert.Contains(t, actual, "              Call to printf took")
-//
-//	// Reset underlying buffer
-//	buf.Reset()
-//
-//	// PluginInstance 2
-//	plugin2, err := NewPlugin(ctx, manifest, config, []HostFunction{})
-//	if err != nil {
-//		panic(err)
-//	}
-//
-//	_, _, _ = plugin2.Call("_start", []byte("hello world"))
-//	plugin2.Close()
-//
-//	// HACK: make sure we give enough time for the events to get flushed
-//	time.Sleep(100 * time.Millisecond)
-//
-//	actual2 := buf.String()
-//	assert.Contains(t, actual2, "  Call to _start took")
-//	assert.Contains(t, actual2, "      Call to main took")
-//	assert.Contains(t, actual2, "        Call to one took")
-//	assert.Contains(t, actual2, "          Call to two took")
-//	assert.Contains(t, actual2, "            Call to three took")
-//	assert.Contains(t, actual2, "              Call to printf took")
-//}
-//
-//// make sure cancelling the context given to NewPlugin doesn't affect plugin calls
-//func TestContextCancel(t *testing.T) {
-//	manifest := manifest("sleep.wasm")
-//	manifest.Config["duration"] = "0" // sleep for 0 seconds
-//
-//	ctx, cancel := context.WithCancel(context.Background())
-//	config := PluginInstanceConfig{
-//		ModuleConfig:  wazero.NewModuleConfig().WithSysWalltime(),
-//		EnableWasi:    true,
-//		RuntimeConfig: wazero.NewRuntimeConfig().WithCloseOnContextDone(true),
-//	}
-//
-//	plugin, err := NewPlugin(ctx, manifest, config, []HostFunction{})
-//
-//	if err != nil {
-//		t.Errorf("Could not create plugin: %v", err)
-//	}
-//
-//	defer plugin.Close()
-//	cancel() // cancel the parent context
-//
-//	exit, out, err := plugin.CallWithContext(context.Background(), "run_test", []byte{})
-//
-//	if assertCall(t, err, exit) {
-//		assert.Equal(t, "slept for 0 seconds", string(out))
-//	}
-//}
-//
-//// make sure we can still turn on experimental wazero features
-//func TestEnableExperimentalFeature(t *testing.T) {
-//	var buf bytes.Buffer
-//
-//	// Set context to one that has an experimental listener
-//	ctx := experimental.WithFunctionListenerFactory(context.Background(), logging.NewHostLoggingListenerFactory(&buf, logging.LogScopeAll))
-//
-//	manifest := manifest("sleep.wasm")
-//	manifest.Config["duration"] = "0" // sleep for 0 seconds
-//
-//	config := PluginInstanceConfig{
-//		ModuleConfig:  wazero.NewModuleConfig().WithSysWalltime(),
-//		EnableWasi:    true,
-//		RuntimeConfig: wazero.NewRuntimeConfig().WithCloseOnContextDone(true),
-//	}
-//
-//	plugin, err := NewPlugin(ctx, manifest, config, []HostFunction{})
-//
-//	if err != nil {
-//		t.Errorf("Could not create plugin: %v", err)
-//	}
-//
-//	defer plugin.Close()
-//
-//	var buf2 bytes.Buffer
-//	ctx = experimental.WithFunctionListenerFactory(context.Background(), logging.NewHostLoggingListenerFactory(&buf2, logging.LogScopeAll))
-//	exit, out, err := plugin.CallWithContext(ctx, "run_test", []byte{})
-//
-//	if assertCall(t, err, exit) {
-//		assert.Equal(t, "slept for 0 seconds", string(out))
-//
-//		assert.NotEmpty(t, buf.String())
-//		assert.Empty(t, buf2.String())
-//	}
-//}
-//
-//func BenchmarkInitialize(b *testing.B) {
-//	ctx := context.Background()
-//	cache := wazero.NewCompilationCache()
-//	defer cache.Close(ctx)
-//
-//	b.ResetTimer()
-//	b.Run("noop", func(b *testing.B) {
-//		b.ReportAllocs()
-//		for i := 0; i < b.N; i++ {
-//			manifest := Manifest{Wasm: []Wasm{WasmFile{Path: "wasm/noop.wasm"}}}
-//
-//			config := PluginInstanceConfig{
-//				EnableWasi:    true,
-//				ModuleConfig:  wazero.NewModuleConfig(),
-//				RuntimeConfig: wazero.NewRuntimeConfig(),
-//			}
-//
-//			_, err := NewPlugin(ctx, manifest, config, []HostFunction{})
-//			if err != nil {
-//				panic(err)
-//			}
-//		}
-//	})
-//}
-//
-//func BenchmarkInitializeWithCache(b *testing.B) {
-//	ctx := context.Background()
-//	cache := wazero.NewCompilationCache()
-//	defer cache.Close(ctx)
-//
-//	b.ResetTimer()
-//	b.Run("noop", func(b *testing.B) {
-//		b.ReportAllocs()
-//		for i := 0; i < b.N; i++ {
-//			manifest := Manifest{Wasm: []Wasm{WasmFile{Path: "wasm/noop.wasm"}}}
-//
-//			config := PluginInstanceConfig{
-//				EnableWasi:    true,
-//				ModuleConfig:  wazero.NewModuleConfig(),
-//				RuntimeConfig: wazero.NewRuntimeConfig().WithCompilationCache(cache),
-//			}
-//
-//			_, err := NewPlugin(ctx, manifest, config, []HostFunction{})
-//			if err != nil {
-//				panic(err)
-//			}
-//		}
-//	})
-//}
-//
-//func BenchmarkNoop(b *testing.B) {
-//	ctx := context.Background()
-//	cache := wazero.NewCompilationCache()
-//	defer cache.Close(ctx)
-//
-//	manifest := Manifest{Wasm: []Wasm{WasmFile{Path: "wasm/noop.wasm"}}}
-//
-//	config := PluginInstanceConfig{
-//		EnableWasi:    true,
-//		ModuleConfig:  wazero.NewModuleConfig(),
-//		RuntimeConfig: wazero.NewRuntimeConfig().WithCompilationCache(cache),
-//	}
-//
-//	plugin, err := NewPlugin(ctx, manifest, config, []HostFunction{})
-//	if err != nil {
-//		panic(err)
-//	}
-//
-//	b.ResetTimer()
-//
-//	b.Run("noop", func(b *testing.B) {
-//		b.ReportAllocs()
-//
-//		for i := 0; i < b.N; i++ {
-//			_, _, err := plugin.Call("run_test", []byte{})
-//			if err != nil {
-//				panic(err)
-//			}
-//		}
-//	})
-//}
+func TestLog_custom(t *testing.T) {
+	manifest := manifest("log.wasm")
+
+	type LogEntry struct {
+		message string
+		level   LogLevel
+	}
+
+	if plugin, ok := plugin(t, manifest); ok {
+		defer plugin.Close(context.Background())
+
+		var actual strings.Builder
+
+		var fmtLogMessage = func(level LogLevel, message string) string {
+			return fmt.Sprintf("%s: %s\n", level.String(), message)
+		}
+
+		plugin.SetLogger(func(level LogLevel, message string) {
+			actual.WriteString(fmtLogMessage(level, message))
+			switch level {
+			case LogLevelDebug:
+				assert.Equal(t, level.String(), "DEBUG")
+			case LogLevelInfo:
+				assert.Equal(t, level.String(), "INFO")
+			case LogLevelWarn:
+				assert.Equal(t, level.String(), "WARN")
+			case LogLevelError:
+				assert.Equal(t, level.String(), "ERROR")
+			case LogLevelTrace:
+				assert.Equal(t, level.String(), "TRACE")
+			}
+		})
+
+		SetLogLevel(LogLevelTrace)
+
+		exit, _, err := plugin.Call("run_test", []byte{})
+
+		if assertCall(t, err, exit) {
+			expected := []LogEntry{
+				{message: "this is a trace log", level: LogLevelTrace},
+				{message: "this is a debug log", level: LogLevelDebug},
+				{message: "this is an info log", level: LogLevelInfo},
+				{message: "this is a warning log", level: LogLevelWarn},
+				{message: "this is an error log", level: LogLevelError},
+			}
+			actualLogs := actual.String()
+			for _, log := range expected {
+				assert.Contains(t, actualLogs, fmtLogMessage(log.level, log.message))
+			}
+		}
+
+		SetLogLevel(LogLevelWarn)
+		actual.Reset()
+
+		exit, _, err = plugin.Call("run_test", []byte{})
+
+		if assertCall(t, err, exit) {
+			expected := []LogEntry{
+				{message: "this is a warning log", level: LogLevelWarn},
+				{message: "this is an error log", level: LogLevelError},
+			}
+			expectedNot := []LogEntry{
+				{message: "this is a trace log", level: LogLevelTrace},
+				{message: "this is a debug log", level: LogLevelDebug},
+				{message: "this is an info log", level: LogLevelInfo},
+			}
+			actualLogs := actual.String()
+			for _, log := range expected {
+				assert.Contains(t, actualLogs, fmtLogMessage(log.level, log.message))
+			}
+			for _, log := range expectedNot {
+				assert.NotContains(t, actualLogs, fmtLogMessage(log.level, log.message))
+			}
+		}
+	}
+}
+
+func TestTimeout(t *testing.T) {
+	manifest := manifest("sleep.wasm")
+	manifest.Timeout = 100            // 100ms
+	manifest.Config["duration"] = "3" // sleep for 3 seconds
+
+	config := PluginConfig{
+		EnableWasi: true,
+	}
+
+	plugin, err := NewPlugin(context.Background(), manifest, config)
+	if err != nil {
+		t.Errorf("Could not create plugin: %v", err)
+	}
+
+	instance, err := plugin.Instance(context.Background(), PluginInstanceConfig{
+		ModuleConfig: wazero.NewModuleConfig().WithSysWalltime(),
+	})
+
+	defer instance.Close(context.Background())
+
+	exit, _, err := instance.Call("run_test", []byte{})
+
+	assert.Equal(t, sys.ExitCodeDeadlineExceeded, exit, "Exit code must be `sys.ExitCodeDeadlineExceeded`")
+	assert.Equal(t, "module closed with context deadline exceeded", err.Error())
+}
+
+func TestCancel(t *testing.T) {
+	manifest := manifest("sleep.wasm")
+	manifest.Config["duration"] = "3" // sleep for 3 seconds
+
+	ctx := context.Background()
+
+	plugin, err := NewPlugin(ctx, manifest, PluginConfig{
+		EnableWasi:    true,
+		RuntimeConfig: wazero.NewRuntimeConfig().WithCloseOnContextDone(true),
+	})
+	if err != nil {
+		t.Errorf("Could not create plugin: %v", err)
+	}
+	defer plugin.Close(ctx)
+
+	instance, err := plugin.Instance(ctx, PluginInstanceConfig{
+		ModuleConfig: wazero.NewModuleConfig().WithSysWalltime(),
+	})
+	if err != nil {
+		t.Errorf("Could not create plugin instance: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	exit, _, err := instance.CallWithContext(ctx, "run_test", []byte{})
+
+	assert.Equal(t, sys.ExitCodeContextCanceled, exit, "Exit code must be `sys.ExitCodeContextCanceled`")
+	assert.Equal(t, "module closed with context canceled", err.Error())
+}
+
+func TestVar(t *testing.T) {
+	manifest := manifest("var.wasm")
+
+	if plugin, ok := plugin(t, manifest); ok {
+		defer plugin.Close(context.Background())
+
+		plugin.Var["a"] = uintToLEBytes(10)
+
+		exit, _, err := plugin.Call("run_test", []byte{})
+
+		if assertCall(t, err, exit) {
+			actual := uintFromLEBytes(plugin.Var["a"])
+			expected := uint(20)
+
+			assert.Equal(t, expected, actual)
+		}
+
+		exit, _, err = plugin.Call("run_test", []byte{})
+
+		if assertCall(t, err, exit) {
+			actual := uintFromLEBytes(plugin.Var["a"])
+			expected := uint(40)
+
+			assert.Equal(t, expected, actual)
+		}
+	}
+
+}
+
+func TestNoVars(t *testing.T) {
+	manifest := manifest("var.wasm")
+	manifest.Memory = &ManifestMemory{MaxVarBytes: 0}
+
+	if plugin, ok := plugin(t, manifest); ok {
+		defer plugin.Close(context.Background())
+
+		plugin.Var["a"] = uintToLEBytes(10)
+
+		_, _, err := plugin.Call("run_test", []byte{})
+
+		if err == nil {
+			t.Fail()
+		}
+	}
+
+}
+
+func TestFS(t *testing.T) {
+	manifest := manifest("fs.wasm")
+	manifest.AllowedPaths = map[string]string{
+		"testdata": "/mnt",
+	}
+
+	if plugin, ok := plugin(t, manifest); ok {
+		defer plugin.Close(context.Background())
+
+		exit, output, err := plugin.Call("run_test", []byte{})
+
+		if assertCall(t, err, exit) {
+			actual := string(output)
+			expected := "hello world!"
+
+			assert.Equal(t, expected, actual)
+		}
+	}
+}
+
+func TestReadOnlyMount(t *testing.T) {
+	manifest := manifest("read_write.wasm")
+	manifest.AllowedPaths = map[string]string{
+		"ro:testdata": "/mnt",
+	}
+
+	if plugin, ok := plugin(t, manifest); ok {
+		defer plugin.Close(context.Background())
+		plugin.Config["path"] = "/mnt/test.txt"
+
+		exit, output, err := plugin.Call("try_read", []byte{})
+
+		if assertCall(t, err, exit) {
+			actual := string(output)
+			expected := "hello world!"
+
+			assert.Equal(t, expected, actual)
+		}
+
+		_, _, err = plugin.Call("try_write", []byte("hello hello!"))
+
+		assert.NotNil(t, err, "Write must fail")
+		assert.Contains(t, err.Error(), "Failed to write file")
+	}
+}
+
+func TestCountVowels(t *testing.T) {
+	manifest := manifest("count_vowels.wasm")
+
+	if plugin, ok := plugin(t, manifest); ok {
+		defer plugin.Close(context.Background())
+
+		exit, output, err := plugin.Call("count_vowels", []byte("hello world"))
+
+		if assertCall(t, err, exit) {
+			expected := 3 // 3 vowels
+
+			var actual map[string]int
+			json.Unmarshal(output, &actual)
+
+			assert.Equal(t, expected, actual["count"])
+		}
+	}
+}
+
+func TestMultipleCallsOutput(t *testing.T) {
+	manifest := manifest("count_vowels.wasm")
+
+	if plugin, ok := plugin(t, manifest); ok {
+		defer plugin.Close(context.Background())
+
+		exit, output1, err := plugin.Call("count_vowels", []byte("aaa"))
+
+		if !assertCall(t, err, exit) {
+			return
+		}
+
+		exit, output2, err := plugin.Call("count_vowels", []byte("bbba"))
+
+		if !assertCall(t, err, exit) {
+			return
+		}
+
+		assert.Equal(t, `{"count":3,"total":3,"vowels":"aeiouAEIOU"}`, string(output1))
+		assert.Equal(t, `{"count":1,"total":4,"vowels":"aeiouAEIOU"}`, string(output2))
+	}
+}
+
+func TestHelloHaskell(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer func() {
+		log.SetOutput(os.Stderr)
+	}()
+
+	manifest := manifest("hello_haskell.wasm")
+
+	if plugin, ok := plugin(t, manifest); ok {
+		defer plugin.Close(context.Background())
+
+		SetLogLevel(LogLevelTrace)
+		plugin.Config["greeting"] = "Howdy"
+
+		exit, output, err := plugin.Call("testing", []byte("John"))
+
+		if assertCall(t, err, exit) {
+			actual := string(output)
+			expected := "Howdy, John"
+
+			assert.Equal(t, expected, actual)
+
+			logs := buf.String()
+
+			assert.Contains(t, logs, "Initialized Haskell language runtime.")
+		}
+	}
+}
+
+func TestJsonManifest(t *testing.T) {
+	m := `
+	{
+		"wasm": [
+		  {
+			"path": "wasm/sleep.wasm"
+		  }
+		],
+		"memory": {
+		  "max_pages": 100
+		},
+		"config": {
+		  "key1": "value1",
+		  "key2": "value2",
+		  "duration": "3"
+		},
+		"timeout_ms": 100
+	}
+	`
+
+	manifest := Manifest{}
+	err := manifest.UnmarshalJSON([]byte(m))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if plugin, ok := plugin(t, manifest); ok {
+		defer plugin.Close(context.Background())
+
+		exit, _, err := plugin.Call("run_test", []byte{})
+
+		assert.Equal(t, sys.ExitCodeDeadlineExceeded, exit, "Exit code must be `sys.ExitCodeDeadlineExceeded`")
+		assert.Equal(t, "module closed with context deadline exceeded", err.Error())
+	}
+}
+
+func TestInputOffset(t *testing.T) {
+	manifest := manifest("input_offset.wasm")
+
+	if plugin, ok := plugin(t, manifest); ok {
+		defer plugin.Close(context.Background())
+
+		input_data := []byte("hello world")
+		exit, output, err := plugin.Call("input_offset_length", input_data)
+
+		if assertCall(t, err, exit) {
+			assert.Equal(t, len(input_data), int(output[0]))
+		}
+	}
+}
+
+func TestObserve(t *testing.T) {
+	ctx := context.Background()
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+
+	adapter := stdout.NewStdoutAdapter()
+	adapter.Start(ctx)
+
+	manifest := manifest("nested.c.instr.wasm")
+
+	config := PluginConfig{
+		EnableWasi:     true,
+		ObserveAdapter: adapter.AdapterBase,
+		ObserveOptions: &observe.Options{
+			SpanFilter:        &observe.SpanFilter{MinDuration: 1 * time.Nanosecond},
+			ChannelBufferSize: 1024,
+		},
+	}
+
+	// PluginInstance 1
+	plugin, err := NewPlugin(ctx, manifest, config)
+	if err != nil {
+		panic(err)
+	}
+
+	instance, err := plugin.Instance(ctx, PluginInstanceConfig{
+		ModuleConfig: wazero.NewModuleConfig().WithSysWalltime(),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	meta := map[string]string{
+		"http.url":         "https://example.com/my-endpoint",
+		"http.status_code": "200",
+		"http.client_ip":   "192.168.1.0",
+	}
+
+	instance.traceCtx.Metadata(meta)
+
+	_, _, _ = instance.Call("_start", []byte("hello world"))
+	plugin.Close(ctx)
+
+	// HACK: make sure we give enough time for the events to get flushed
+	time.Sleep(100 * time.Millisecond)
+
+	actual := buf.String()
+	assert.Contains(t, actual, "  Call to _start took")
+	assert.Contains(t, actual, "      Call to main took")
+	assert.Contains(t, actual, "        Call to one took")
+	assert.Contains(t, actual, "          Call to two took")
+	assert.Contains(t, actual, "            Call to three took")
+	assert.Contains(t, actual, "              Call to printf took")
+
+	// Reset underlying buffer
+	buf.Reset()
+
+	// PluginInstance 2
+	plugin2, err := NewPlugin(ctx, manifest, config)
+	if err != nil {
+		panic(err)
+	}
+
+	instance2, err := plugin2.Instance(ctx, PluginInstanceConfig{
+		ModuleConfig: wazero.NewModuleConfig().WithSysWalltime(),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	_, _, _ = instance2.Call("_start", []byte("hello world"))
+	plugin2.Close(ctx)
+
+	// HACK: make sure we give enough time for the events to get flushed
+	time.Sleep(100 * time.Millisecond)
+
+	actual2 := buf.String()
+	assert.Contains(t, actual2, "  Call to _start took")
+	assert.Contains(t, actual2, "      Call to main took")
+	assert.Contains(t, actual2, "        Call to one took")
+	assert.Contains(t, actual2, "          Call to two took")
+	assert.Contains(t, actual2, "            Call to three took")
+	assert.Contains(t, actual2, "              Call to printf took")
+}
+
+// make sure cancelling the context given to NewPlugin doesn't affect plugin calls
+func TestContextCancel(t *testing.T) {
+	manifest := manifest("sleep.wasm")
+	manifest.Config["duration"] = "0" // sleep for 0 seconds
+
+	ctx, cancel := context.WithCancel(context.Background())
+	config := PluginConfig{
+		EnableWasi:    true,
+		RuntimeConfig: wazero.NewRuntimeConfig().WithCloseOnContextDone(true),
+	}
+
+	plugin, err := NewPlugin(ctx, manifest, config)
+	if err != nil {
+		t.Errorf("Could not create plugin: %v", err)
+	}
+
+	instance, err := plugin.Instance(ctx, PluginInstanceConfig{
+		ModuleConfig: wazero.NewModuleConfig().WithSysWalltime(),
+	})
+
+	defer plugin.Close(context.Background())
+	cancel() // cancel the parent context
+
+	exit, out, err := instance.CallWithContext(context.Background(), "run_test", []byte{})
+
+	if assertCall(t, err, exit) {
+		assert.Equal(t, "slept for 0 seconds", string(out))
+	}
+}
+
+// make sure we can still turn on experimental wazero features
+func TestEnableExperimentalFeature(t *testing.T) {
+	var buf bytes.Buffer
+
+	// Set context to one that has an experimental listener
+	ctx := experimental.WithFunctionListenerFactory(context.Background(), logging.NewHostLoggingListenerFactory(&buf, logging.LogScopeAll))
+
+	manifest := manifest("sleep.wasm")
+	manifest.Config["duration"] = "0" // sleep for 0 seconds
+
+	config := PluginConfig{
+		EnableWasi:    true,
+		RuntimeConfig: wazero.NewRuntimeConfig().WithCloseOnContextDone(true),
+	}
+
+	plugin, err := NewPlugin(ctx, manifest, config)
+	if err != nil {
+		t.Errorf("Could not create plugin: %v", err)
+	}
+	defer plugin.Close(context.Background())
+
+	instance, err := plugin.Instance(ctx, PluginInstanceConfig{
+		ModuleConfig: wazero.NewModuleConfig().WithSysWalltime(),
+	})
+	defer instance.Close(ctx)
+
+	var buf2 bytes.Buffer
+	ctx = experimental.WithFunctionListenerFactory(context.Background(), logging.NewHostLoggingListenerFactory(&buf2, logging.LogScopeAll))
+	exit, out, err := instance.CallWithContext(ctx, "run_test", []byte{})
+
+	if assertCall(t, err, exit) {
+		assert.Equal(t, "slept for 0 seconds", string(out))
+
+		assert.NotEmpty(t, buf.String())
+		assert.Empty(t, buf2.String())
+	}
+}
+
+func BenchmarkInitialize(b *testing.B) {
+	ctx := context.Background()
+	cache := wazero.NewCompilationCache()
+	defer cache.Close(ctx)
+
+	b.ResetTimer()
+	b.Run("noop", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			manifest := Manifest{Wasm: []Wasm{WasmFile{Path: "wasm/noop.wasm"}}}
+
+			config := PluginConfig{
+				EnableWasi:    true,
+				RuntimeConfig: wazero.NewRuntimeConfig(),
+			}
+
+			plugin, err := NewPlugin(ctx, manifest, config)
+			if err != nil {
+				panic(err)
+			}
+
+			_, err = plugin.Instance(ctx, PluginInstanceConfig{
+				ModuleConfig: wazero.NewModuleConfig(),
+			})
+			if err != nil {
+				panic(err)
+			}
+		}
+	})
+}
+
+func BenchmarkInitializeWithCache(b *testing.B) {
+	ctx := context.Background()
+	cache := wazero.NewCompilationCache()
+	defer cache.Close(ctx)
+
+	b.ResetTimer()
+	b.Run("noop", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			manifest := Manifest{Wasm: []Wasm{WasmFile{Path: "wasm/noop.wasm"}}}
+
+			config := PluginConfig{
+				EnableWasi:    true,
+				RuntimeConfig: wazero.NewRuntimeConfig().WithCompilationCache(cache),
+			}
+
+			plugin, err := NewPlugin(ctx, manifest, config)
+			if err != nil {
+				panic(err)
+			}
+
+			_, err = plugin.Instance(ctx, PluginInstanceConfig{
+				ModuleConfig: wazero.NewModuleConfig(),
+			})
+			if err != nil {
+				panic(err)
+			}
+		}
+	})
+}
+
+func BenchmarkNoop(b *testing.B) {
+	ctx := context.Background()
+	cache := wazero.NewCompilationCache()
+	defer cache.Close(ctx)
+
+	manifest := Manifest{Wasm: []Wasm{WasmFile{Path: "wasm/noop.wasm"}}}
+
+	config := PluginConfig{
+		EnableWasi:    true,
+		RuntimeConfig: wazero.NewRuntimeConfig().WithCompilationCache(cache),
+	}
+
+	plugin, err := NewPlugin(ctx, manifest, config)
+	if err != nil {
+		panic(err)
+	}
+	defer plugin.Close(ctx)
+
+	instance, err := plugin.Instance(ctx, PluginInstanceConfig{
+		ModuleConfig: wazero.NewModuleConfig(),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	b.ResetTimer()
+
+	b.Run("noop", func(b *testing.B) {
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			_, _, err := instance.Call("run_test", []byte{})
+			if err != nil {
+				panic(err)
+			}
+		}
+	})
+}
 
 var (
 	Regex2048 = "BYwnOjWhprPmDncp8qpQ5CY4r1RGZuqKLBowmtMCd test ETjLOG685YC4RIjXB0HadNpqYS4M7GPGUVAKRZRC1ibqQqGnuzqX2Hjosm6MKNCp5QifX7Up2phqkFqkjpSu3k59oi6M5YbTMiy4JukVFx2402IlrHU1McK7US0skB1cF0W2ZDpsypNmGJRXRMY0pPsYbw7G2a0xJnhTITXcuF5xJWR1rz5zdGZQbbjZoHZcEnveDFq5kOmCVc test DsJVHTsAlypLI9sVtbTLwmE1DG2C6AgUo3GO1DpCx3jV43oXUxaTVJqZO13AYqvNPbxizYZ5BckZFBbJybY3Vnm20Sm7nXbwZs5N2ugz3EpUQvXwqHdHWzc1T8uKPD5LTDM8UBpVoF test 9G3mWarrp43SvoidITriFhzHmyVWNd6n2LIVocr3pOai4DOlkAn7QDup6z6spMAf8UcI4wbfoSzG0k5Qy1rGBhPaJKJRW2 MC9ma3U3rnjAOBtEUHZ2qfOUpfMNgPlGpvzr4IGNNFf9RFlF7yRUBvRnYxyonIWPPiR1x1wWgxc20o5cW4GU7kytAOuGlpzpykcAxCJLLP6wJegaMhAeb8xBLpuBetNEbfcyyOcJBun5BhmFOmv8 test IvICWx2wlYZ61YDBpPcIpqnMb9MHwT8GroC1YITZBlNGBHMpAe4d2sNZe9d0Wvfbv5mMo30Bm1Pa5S3x38jgu6y0BaqZl9GhlukE9CqPJGUsJZ5suDH19WiOrvz7mXwXhi4lWm1YdwNi0xhVnXITtmKq5rikIS6dul1USgDf3TwyLYpyCG46Xj92PssJmnhPdH1WAnvXY sbs8RaemyqmPggtGNwU2JjuPjdmQRakIusv2WimN7zG8R8Pf1225IAJ2j8aiZBrxnjmrucaYOQCrLm7e2Q5q8 test HOkCEJJGHVLYJtGgHKa1PRQ5qCcsIAUdkW3yRfdulutteLe3We9z9XQvWuTYMLDPpOJqMzDNTGpTYts7AL8pFog1k82XVuMZ6ItccxOBpuzDcahH4wDqCGjak8qPVxmnrGmSsrdUHVz6SrScElMo0nOF8RIpYAVdJr5NxWIK1uzc1iIiZnbUD6uDNmBkmfec6IgK6aqnEZaGLDJXDHSYfzWUOi7y3KNPl0CghL9BId8v4040mCKMfmdthWWLJ2tpWIo1482ghiU5 2qtrzgFgYKfyfr4X6FXzN3hM3bLnuwItQrTCEp3BYz79bCAaQGhicZzqE83Mh2 test IIVID622qlEyVEGuEmNJ5JteEzbpklhTKnVMflzzWyWbZe6kIgeUr9mxWjkJGisvRbZKwfnojeC82M1nHgUa4k46x7Dw7mL3rChORjBxBMYjFeOvCsT6kEo3vPeachLUKdkExJbr9Yei0fKyOFSDlxpFhlRKuwGxXu4jGo4CzKDsVsahqzC9iGw53bHiw0V4Pwmdhzv482s3zU9XLTgQr6GuL1I0kSfh9BkVoK5fFvg1hm7ECrt6p8q3kLVjxte EK9W9q2q9etMaPLymcCRZ0XauMDzJY08JeVvovnT2g5hxE7UGW1 test YRotQUivrrXQnhEw55faznZZBU1ULVs4BfYkIkEfS91NetBhona6zrzDwMsXi0FJjdaiJ25lvetPDaMzUs0l6nfkGkVyU376mFPfPkpBKZR2z2Xwzxndi0SkUnqm8jCa7iq2oSJstTdUXtCK2xTXMIh7tiuPVftit GFYQXXI3vY QFe1xShWJgFAqYguQ8gcxMPSzMlyDaPmMuTPgFZDM0cd test NS3fTggxBa4p5jgS4S0nhae05RkYkXGzuNMXeu6IoR9PFqVFnXcBYD0Ld9otrAiqUuIGYGmAjm3Wx29va2UtIFaRhL02ckRfycz3BGfwqYl3TGtjWdKjmxn1WreRIIq5gkbWJws5VQsov0V2U8pGedj N2RDqWgh2tFiJA9fmytgRgqSnqxIwyBMgY5RnE6CZ0 test Iv4QPiWMu0oG70e4nSNtG13O test "
@@ -1096,70 +1144,74 @@ var (
 	Match65536 = Match32768 + Match32768
 )
 
-//func BenchmarkReplace(b *testing.B) {
-//	ctx := context.Background()
-//	cache := wazero.NewCompilationCache()
-//	defer cache.Close(ctx)
-//
-//	manifest := Manifest{Wasm: []Wasm{WasmFile{Path: "wasm/replace.wasm"}}}
-//
-//	config := PluginInstanceConfig{
-//		EnableWasi:    true,
-//		ModuleConfig:  wazero.NewModuleConfig(),
-//		RuntimeConfig: wazero.NewRuntimeConfig().WithCompilationCache(cache),
-//	}
-//
-//	plugin, err := NewPlugin(ctx, manifest, config, []HostFunction{})
-//	if err != nil {
-//		panic(err)
-//	}
-//
-//	b.ResetTimer()
-//
-//	inputs := map[string][]byte{
-//		"empty": {},
-//		"2048":  []byte(Regex2048),
-//		"4096":  []byte(Regex4096),
-//		"8192":  []byte(Regex8192),
-//		"16383": []byte(Regex16384),
-//		"32768": []byte(Regex32768),
-//	}
-//
-//	expected := map[string][]byte{
-//		"empty": {},
-//		"2048":  []byte(Match2048),
-//		"4096":  []byte(Match4096),
-//		"8192":  []byte(Match8192),
-//		"16383": []byte(Match16384),
-//		"32768": []byte(Match32768),
-//	}
-//
-//	for k, v := range inputs {
-//		expected := expected[k]
-//		b.Run(k, func(b *testing.B) {
-//			input := v
-//			b.SetBytes(int64(len(input)))
-//			b.ReportAllocs()
-//
-//			for i := 0; i < b.N; i++ {
-//				_, out, err := plugin.Call("run_test", input)
-//				if err != nil {
-//					fmt.Println("SOMETHING BAD HAPPENED: ", err)
-//					panic(err)
-//				}
-//
-//				if !equal(out, expected) {
-//					fmt.Println(string(out))
-//					panic("invalid regex match")
-//				}
-//			}
-//		})
-//	}
-//}
+func BenchmarkReplace(b *testing.B) {
+	ctx := context.Background()
+	cache := wazero.NewCompilationCache()
+	defer cache.Close(ctx)
+
+	manifest := Manifest{Wasm: []Wasm{WasmFile{Path: "wasm/replace.wasm"}}}
+
+	config := PluginConfig{
+		EnableWasi:    true,
+		RuntimeConfig: wazero.NewRuntimeConfig().WithCompilationCache(cache),
+	}
+
+	plugin, err := NewPlugin(ctx, manifest, config)
+	if err != nil {
+		panic(err)
+	}
+	defer plugin.Close(ctx)
+
+	instance, err := plugin.Instance(ctx, PluginInstanceConfig{
+		ModuleConfig: wazero.NewModuleConfig(),
+	})
+
+	b.ResetTimer()
+
+	inputs := map[string][]byte{
+		"empty": {},
+		"2048":  []byte(Regex2048),
+		"4096":  []byte(Regex4096),
+		"8192":  []byte(Regex8192),
+		"16383": []byte(Regex16384),
+		"32768": []byte(Regex32768),
+	}
+
+	expected := map[string][]byte{
+		"empty": {},
+		"2048":  []byte(Match2048),
+		"4096":  []byte(Match4096),
+		"8192":  []byte(Match8192),
+		"16383": []byte(Match16384),
+		"32768": []byte(Match32768),
+	}
+
+	for k, v := range inputs {
+		expected := expected[k]
+		b.Run(k, func(b *testing.B) {
+			input := v
+			b.SetBytes(int64(len(input)))
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				_, out, err := instance.Call("run_test", input)
+				if err != nil {
+					fmt.Println("SOMETHING BAD HAPPENED: ", err)
+					panic(err)
+				}
+
+				if !equal(out, expected) {
+					fmt.Println(string(out))
+					panic("invalid regex match")
+				}
+			}
+		})
+	}
+}
 
 func wasiPluginConfig() PluginInstanceConfig {
 	config := PluginInstanceConfig{
-		ModuleConfig: wazero.NewModuleConfig().WithSysWalltime(),
+		ModuleConfig: wazero.NewModuleConfig().WithSysWalltime().WithStdout(os.Stdout).WithStderr(os.Stderr),
 	}
 	return config
 }
@@ -1227,38 +1279,3 @@ func uintToLEBytes(num uint) []byte {
 func uintFromLEBytes(bytes []byte) uint {
 	return uint(bytes[0]) | uint(bytes[1])<<8 | uint(bytes[2])<<16 | uint(bytes[3])<<24
 }
-
-//func TestFoobar(t *testing.T) {
-//	r := wazero.NewRuntimeWithConfig(context.Background(), wazero.NewRuntimeConfig())
-//
-//	manifest := manifest("host.wasm")
-//
-//	//mult := NewHostFunctionWithStack(
-//	//	"mult",
-//	//	func(ctx context.Context, plugin *CurrentPlugin, stack []uint64) {
-//	//		a := DecodeI32(stack[0])
-//	//		b := DecodeI32(stack[1])
-//	//
-//	//		stack[0] = EncodeI32(a * b)
-//	//	},
-//	//	[]ValueType{ValueTypePTR, ValueTypePTR},
-//	//	[]ValueType{ValueTypePTR},
-//	//)
-//	wasm, err := manifest.Wasm[0].ToWasmData(context.Background())
-//	if err != nil {
-//		panic(err)
-//	}
-//
-//	compiled, err := r.CompileModule(context.Background(), wasm.Data)
-//	if err != nil {
-//		panic(err)
-//	}
-//
-//	r2 := wazero.NewRuntime(context.Background())
-//	module, err := r2.InstantiateModule(context.Background(), compiled, wazero.NewModuleConfig())
-//	if err != nil {
-//		panic(err)
-//	}
-//
-//	_ = module
-//}

--- a/extism_test.go
+++ b/extism_test.go
@@ -35,7 +35,7 @@ func TestWasmUrl(t *testing.T) {
 	}
 
 	_, ok := plugin(t, manifest)
-	assert.True(t, ok, "PluginInstance must be succussfuly created")
+	assert.True(t, ok, "InstantiatedPlugin must be succussfuly created")
 }
 
 func TestHashMismatch(t *testing.T) {
@@ -55,11 +55,11 @@ func TestHashMismatch(t *testing.T) {
 	ctx := context.Background()
 	//config := wasiPluginConfig()
 
-	_, err := NewPlugin(ctx, manifest, PluginConfig{
+	_, err := NewCompiledPlugin(ctx, manifest, PluginConfig{
 		EnableWasi: true,
 	})
 
-	assert.NotNil(t, err, "PluginInstance must fail")
+	assert.NotNil(t, err, "InstantiatedPlugin must fail")
 }
 
 func TestFunctionExsits(t *testing.T) {
@@ -360,7 +360,7 @@ func TestHost_multiple(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	p, err := NewPlugin(ctx, manifest, PluginConfig{
+	p, err := NewCompiledPlugin(ctx, manifest, PluginConfig{
 		EnableWasi:    true,
 		HostFunctions: hostFunctions,
 	})
@@ -602,7 +602,7 @@ func TestTimeout(t *testing.T) {
 		EnableWasi: true,
 	}
 
-	plugin, err := NewPlugin(context.Background(), manifest, config)
+	plugin, err := NewCompiledPlugin(context.Background(), manifest, config)
 	if err != nil {
 		t.Errorf("Could not create plugin: %v", err)
 	}
@@ -625,7 +625,7 @@ func TestCancel(t *testing.T) {
 
 	ctx := context.Background()
 
-	plugin, err := NewPlugin(ctx, manifest, PluginConfig{
+	plugin, err := NewCompiledPlugin(ctx, manifest, PluginConfig{
 		EnableWasi:    true,
 		RuntimeConfig: wazero.NewRuntimeConfig().WithCloseOnContextDone(true),
 	})
@@ -889,8 +889,8 @@ func TestObserve(t *testing.T) {
 		},
 	}
 
-	// PluginInstance 1
-	plugin, err := NewPlugin(ctx, manifest, config)
+	// InstantiatedPlugin 1
+	plugin, err := NewCompiledPlugin(ctx, manifest, config)
 	if err != nil {
 		panic(err)
 	}
@@ -927,8 +927,8 @@ func TestObserve(t *testing.T) {
 	// Reset underlying buffer
 	buf.Reset()
 
-	// PluginInstance 2
-	plugin2, err := NewPlugin(ctx, manifest, config)
+	// InstantiatedPlugin 2
+	plugin2, err := NewCompiledPlugin(ctx, manifest, config)
 	if err != nil {
 		panic(err)
 	}
@@ -955,7 +955,7 @@ func TestObserve(t *testing.T) {
 	assert.Contains(t, actual2, "              Call to printf took")
 }
 
-// make sure cancelling the context given to NewPlugin doesn't affect plugin calls
+// make sure cancelling the context given to NewCompiledPlugin doesn't affect plugin calls
 func TestContextCancel(t *testing.T) {
 	manifest := manifest("sleep.wasm")
 	manifest.Config["duration"] = "0" // sleep for 0 seconds
@@ -966,7 +966,7 @@ func TestContextCancel(t *testing.T) {
 		RuntimeConfig: wazero.NewRuntimeConfig().WithCloseOnContextDone(true),
 	}
 
-	plugin, err := NewPlugin(ctx, manifest, config)
+	plugin, err := NewCompiledPlugin(ctx, manifest, config)
 	if err != nil {
 		t.Errorf("Could not create plugin: %v", err)
 	}
@@ -1000,7 +1000,7 @@ func TestEnableExperimentalFeature(t *testing.T) {
 		RuntimeConfig: wazero.NewRuntimeConfig().WithCloseOnContextDone(true),
 	}
 
-	plugin, err := NewPlugin(ctx, manifest, config)
+	plugin, err := NewCompiledPlugin(ctx, manifest, config)
 	if err != nil {
 		t.Errorf("Could not create plugin: %v", err)
 	}
@@ -1039,7 +1039,7 @@ func BenchmarkInitialize(b *testing.B) {
 				RuntimeConfig: wazero.NewRuntimeConfig(),
 			}
 
-			plugin, err := NewPlugin(ctx, manifest, config)
+			plugin, err := NewCompiledPlugin(ctx, manifest, config)
 			if err != nil {
 				panic(err)
 			}
@@ -1070,7 +1070,7 @@ func BenchmarkInitializeWithCache(b *testing.B) {
 				RuntimeConfig: wazero.NewRuntimeConfig().WithCompilationCache(cache),
 			}
 
-			plugin, err := NewPlugin(ctx, manifest, config)
+			plugin, err := NewCompiledPlugin(ctx, manifest, config)
 			if err != nil {
 				panic(err)
 			}
@@ -1097,7 +1097,7 @@ func BenchmarkNoop(b *testing.B) {
 		RuntimeConfig: wazero.NewRuntimeConfig().WithCompilationCache(cache),
 	}
 
-	plugin, err := NewPlugin(ctx, manifest, config)
+	plugin, err := NewCompiledPlugin(ctx, manifest, config)
 	if err != nil {
 		panic(err)
 	}
@@ -1156,7 +1156,7 @@ func BenchmarkReplace(b *testing.B) {
 		RuntimeConfig: wazero.NewRuntimeConfig().WithCompilationCache(cache),
 	}
 
-	plugin, err := NewPlugin(ctx, manifest, config)
+	plugin, err := NewCompiledPlugin(ctx, manifest, config)
 	if err != nil {
 		panic(err)
 	}
@@ -1232,11 +1232,11 @@ func manifest(name string) Manifest {
 	return manifest
 }
 
-func plugin(t *testing.T, manifest Manifest, funcs ...HostFunction) (*PluginInstance, bool) {
+func plugin(t *testing.T, manifest Manifest, funcs ...HostFunction) (*InstantiatedPlugin, bool) {
 	ctx := context.Background()
 	config := wasiPluginConfig()
 
-	plugin, err := NewPlugin(ctx, manifest, PluginConfig{
+	plugin, err := NewCompiledPlugin(ctx, manifest, PluginConfig{
 		EnableWasi:    true,
 		HostFunctions: funcs,
 	})

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dylibso/observe-sdk/go v0.0.0-20240819160327-2d926c5d788a
 	github.com/gobwas/glob v0.2.3
 	github.com/stretchr/testify v1.9.0
-	github.com/tetratelabs/wazero v1.8.1-0.20240916092830-1353ca24fef0
+	github.com/tetratelabs/wazero v1.8.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 h1:ZF+QBjOI+tILZ
 github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834/go.mod h1:m9ymHTgNSEjuxvw8E7WWe4Pl4hZQHXONY8wE6dMLaRk=
 github.com/tetratelabs/wazero v1.8.1-0.20240916092830-1353ca24fef0 h1:NCRnJ+X6eZt3awiReoHCcDuC6Wf+CgWk6p4IDkIuxTo=
 github.com/tetratelabs/wazero v1.8.1-0.20240916092830-1353ca24fef0/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
+github.com/tetratelabs/wazero v1.8.1 h1:NrcgVbWfkWvVc4UtT4LRLDf91PsOzDzefMdwhLfA550=
+github.com/tetratelabs/wazero v1.8.1/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
 go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeXrui0=
 go.opentelemetry.io/proto/otlp v1.3.1/go.mod h1:0X1WI4de4ZsLrrJNLAQbFeLCm3T7yBkR0XqQ7niQU+8=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/host.go
+++ b/host.go
@@ -248,7 +248,7 @@ func defineCustomHostFunctions(builder wazero.HostModuleBuilder, funcs []HostFun
 	}
 }
 
-func buildEnvModule(ctx context.Context, rt wazero.Runtime, extism api.Module) (wazero.CompiledModule, error) {
+func buildEnvModule(ctx context.Context, rt wazero.Runtime, extism api.Module) (api.Module, error) {
 	builder := rt.NewHostModuleBuilder("extism:host/env")
 
 	wrap := func(name string, params []ValueType, results []ValueType) {
@@ -337,7 +337,7 @@ func buildEnvModule(ctx context.Context, rt wazero.Runtime, extism api.Module) (
 	logFunc("log_warn", LogLevelWarn)
 	logFunc("log_error", LogLevelError)
 
-	return builder.Compile(ctx)
+	return builder.Instantiate(ctx)
 }
 
 func store_u64(ctx context.Context, mod api.Module, stack []uint64) {

--- a/host.go
+++ b/host.go
@@ -129,7 +129,7 @@ func (p *CurrentPlugin) Alloc(n uint64) (uint64, error) {
 
 // Alloc a new memory block of the given length, returning its offset
 func (p *CurrentPlugin) AllocWithContext(ctx context.Context, n uint64) (uint64, error) {
-	out, err := p.plugin.plugin.extism.ExportedFunction("alloc").Call(ctx, uint64(n))
+	out, err := p.plugin.extism.ExportedFunction("alloc").Call(ctx, uint64(n))
 	if err != nil {
 		return 0, err
 	} else if len(out) != 1 {
@@ -146,7 +146,7 @@ func (p *CurrentPlugin) Free(offset uint64) error {
 
 // Free the memory block specified by the given offset
 func (p *CurrentPlugin) FreeWithContext(ctx context.Context, offset uint64) error {
-	_, err := p.plugin.plugin.extism.ExportedFunction("free").Call(ctx, uint64(offset))
+	_, err := p.plugin.extism.ExportedFunction("free").Call(ctx, uint64(offset))
 	if err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ func (p *CurrentPlugin) Length(offs uint64) (uint64, error) {
 
 // Length returns the number of bytes allocated at the specified offset
 func (p *CurrentPlugin) LengthWithContext(ctx context.Context, offs uint64) (uint64, error) {
-	out, err := p.plugin.plugin.extism.ExportedFunction("length").Call(ctx, uint64(offs))
+	out, err := p.plugin.extism.ExportedFunction("length").Call(ctx, uint64(offs))
 	if err != nil {
 		return 0, err
 	} else if len(out) != 1 {

--- a/host.go
+++ b/host.go
@@ -248,14 +248,25 @@ func defineCustomHostFunctions(builder wazero.HostModuleBuilder, funcs []HostFun
 	}
 }
 
-func buildEnvModule(ctx context.Context, rt wazero.Runtime, extism api.Module) (api.Module, error) {
+func instantiateEnvModule(ctx context.Context, rt wazero.Runtime) (api.Module, error) {
 	builder := rt.NewHostModuleBuilder("extism:host/env")
 
-	wrap := func(name string, params []ValueType, results []ValueType) {
-		f := extism.ExportedFunction(name)
+	// A wrapper that creates allows calls from guest -> go host -> extism kernel wasm
+	// See https://github.com/extism/proposals/blob/main/EIP-007-extism-runtime-kernel.md.
+	extismFunc := func(name string, params []ValueType, results []ValueType) {
 		builder.
 			NewFunctionBuilder().
 			WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+				extism, ok := ctx.Value(PluginCtxKey("extism")).(api.Module)
+				if !ok {
+					panic("Invalid context, `extism` key not found")
+				}
+
+				f := extism.ExportedFunction(name)
+				if f == nil {
+					panic(fmt.Errorf("function %q not found in extism:host", name))
+				}
+
 				err := f.CallWithStack(ctx, stack)
 				if err != nil {
 					panic(err)
@@ -264,24 +275,24 @@ func buildEnvModule(ctx context.Context, rt wazero.Runtime, extism api.Module) (
 			Export(name)
 	}
 
-	wrap("alloc", []ValueType{ValueTypeI64}, []ValueType{ValueTypeI64})
-	wrap("free", []ValueType{ValueTypeI64}, []ValueType{})
-	wrap("load_u8", []ValueType{ValueTypeI64}, []ValueType{ValueTypeI32})
-	wrap("input_load_u8", []ValueType{ValueTypeI64}, []ValueType{ValueTypeI32})
-	wrap("store_u64", []ValueType{ValueTypeI64, ValueTypeI64}, []ValueType{})
-	wrap("store_u8", []ValueType{ValueTypeI64, ValueTypeI32}, []ValueType{})
-	wrap("input_set", []ValueType{ValueTypeI64, ValueTypeI64}, []ValueType{})
-	wrap("output_set", []ValueType{ValueTypeI64, ValueTypeI64}, []ValueType{})
-	wrap("input_length", []ValueType{}, []ValueType{ValueTypeI64})
-	wrap("input_offset", []ValueType{}, []ValueType{ValueTypeI64})
-	wrap("output_length", []ValueType{}, []ValueType{ValueTypeI64})
-	wrap("output_offset", []ValueType{}, []ValueType{ValueTypeI64})
-	wrap("length", []ValueType{ValueTypeI64}, []ValueType{ValueTypeI64})
-	wrap("length_unsafe", []ValueType{ValueTypeI64}, []ValueType{ValueTypeI64})
-	wrap("reset", []ValueType{}, []ValueType{})
-	wrap("error_set", []ValueType{ValueTypeI64}, []ValueType{})
-	wrap("error_get", []ValueType{}, []ValueType{ValueTypeI64})
-	wrap("memory_bytes", []ValueType{}, []ValueType{ValueTypeI64})
+	extismFunc("alloc", []ValueType{ValueTypeI64}, []ValueType{ValueTypeI64})
+	extismFunc("free", []ValueType{ValueTypeI64}, []ValueType{})
+	extismFunc("load_u8", []ValueType{ValueTypeI64}, []ValueType{ValueTypeI32})
+	extismFunc("input_load_u8", []ValueType{ValueTypeI64}, []ValueType{ValueTypeI32})
+	extismFunc("store_u64", []ValueType{ValueTypeI64, ValueTypeI64}, []ValueType{})
+	extismFunc("store_u8", []ValueType{ValueTypeI64, ValueTypeI32}, []ValueType{})
+	extismFunc("input_set", []ValueType{ValueTypeI64, ValueTypeI64}, []ValueType{})
+	extismFunc("output_set", []ValueType{ValueTypeI64, ValueTypeI64}, []ValueType{})
+	extismFunc("input_length", []ValueType{}, []ValueType{ValueTypeI64})
+	extismFunc("input_offset", []ValueType{}, []ValueType{ValueTypeI64})
+	extismFunc("output_length", []ValueType{}, []ValueType{ValueTypeI64})
+	extismFunc("output_offset", []ValueType{}, []ValueType{ValueTypeI64})
+	extismFunc("length", []ValueType{ValueTypeI64}, []ValueType{ValueTypeI64})
+	extismFunc("length_unsafe", []ValueType{ValueTypeI64}, []ValueType{ValueTypeI64})
+	extismFunc("reset", []ValueType{}, []ValueType{})
+	extismFunc("error_set", []ValueType{ValueTypeI64}, []ValueType{})
+	extismFunc("error_get", []ValueType{}, []ValueType{ValueTypeI64})
+	extismFunc("memory_bytes", []ValueType{}, []ValueType{ValueTypeI64})
 
 	builder.NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(api.GoModuleFunc(inputLoad_u64)), []ValueType{ValueTypeI64}, []ValueType{ValueTypeI64}).
@@ -617,7 +628,7 @@ func httpHeaders(ctx context.Context, _ api.Module) uint64 {
 }
 
 func getLogLevel(ctx context.Context, m api.Module) int32 {
-	// if _, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
+	// if _, ok := callCtx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
 	// 	panic("Invalid context, `plugin` key not found")
 	// }
 	return LogLevel(pluginLogLevel.Load()).ExtismCompat()

--- a/host.go
+++ b/host.go
@@ -102,10 +102,10 @@ func NewHostFunctionWithStack(
 }
 
 type CurrentPlugin struct {
-	plugin *PluginInstance
+	plugin *InstantiatedPlugin
 }
 
-func (p *PluginInstance) currentPlugin() *CurrentPlugin {
+func (p *InstantiatedPlugin) currentPlugin() *CurrentPlugin {
 	return &CurrentPlugin{p}
 }
 
@@ -238,7 +238,7 @@ func defineCustomHostFunctions(builder wazero.HostModuleBuilder, funcs []HostFun
 		closure := f.stackCallback
 
 		builder.NewFunctionBuilder().WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
-			if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*PluginInstance); ok {
+			if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
 				closure(ctx, &CurrentPlugin{plugin}, stack)
 				return
 			}
@@ -309,7 +309,7 @@ func buildEnvModule(ctx context.Context, rt wazero.Runtime, extism api.Module) (
 
 	logFunc := func(name string, level LogLevel) {
 		hostFunc(name, func(ctx context.Context, m api.Module, offset uint64) {
-			if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*PluginInstance); ok {
+			if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
 				if LogLevel(pluginLogLevel.Load()) > level {
 					plugin.currentPlugin().Free(offset)
 					return
@@ -341,7 +341,7 @@ func buildEnvModule(ctx context.Context, rt wazero.Runtime, extism api.Module) (
 }
 
 func store_u64(ctx context.Context, mod api.Module, stack []uint64) {
-	p, ok := ctx.Value(PluginCtxKey("plugin")).(*PluginInstance)
+	p, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin)
 	if !ok {
 		panic("Invalid context")
 	}
@@ -355,7 +355,7 @@ func store_u64(ctx context.Context, mod api.Module, stack []uint64) {
 }
 
 func load_u64(ctx context.Context, mod api.Module, stack []uint64) {
-	p, ok := ctx.Value(PluginCtxKey("plugin")).(*PluginInstance)
+	p, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin)
 	if !ok {
 		panic("Invalid context")
 	}
@@ -367,7 +367,7 @@ func load_u64(ctx context.Context, mod api.Module, stack []uint64) {
 }
 
 func inputLoad_u64(ctx context.Context, mod api.Module, stack []uint64) {
-	p, ok := ctx.Value(PluginCtxKey("plugin")).(*PluginInstance)
+	p, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin)
 	if !ok {
 		panic("Invalid context")
 	}
@@ -384,7 +384,7 @@ func inputLoad_u64(ctx context.Context, mod api.Module, stack []uint64) {
 }
 
 func configGet(ctx context.Context, m api.Module, offset uint64) uint64 {
-	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*PluginInstance); ok {
+	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
 		cp := plugin.currentPlugin()
 
 		name, err := cp.ReadString(offset)
@@ -410,7 +410,7 @@ func configGet(ctx context.Context, m api.Module, offset uint64) uint64 {
 }
 
 func varGet(ctx context.Context, m api.Module, offset uint64) uint64 {
-	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*PluginInstance); ok {
+	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
 		cp := plugin.currentPlugin()
 
 		name, err := cp.ReadString(offset)
@@ -438,7 +438,7 @@ func varGet(ctx context.Context, m api.Module, offset uint64) uint64 {
 }
 
 func varSet(ctx context.Context, m api.Module, nameOffset uint64, valueOffset uint64) {
-	plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*PluginInstance)
+	plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin)
 	if !ok {
 		panic("Invalid context, `plugin` key not found")
 	}
@@ -485,7 +485,7 @@ func varSet(ctx context.Context, m api.Module, nameOffset uint64, valueOffset ui
 }
 
 func httpRequest(ctx context.Context, m api.Module, requestOffset uint64, bodyOffset uint64) uint64 {
-	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*PluginInstance); ok {
+	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
 		cp := plugin.currentPlugin()
 
 		if plugin.LastResponseHeaders != nil {
@@ -589,7 +589,7 @@ func httpRequest(ctx context.Context, m api.Module, requestOffset uint64, bodyOf
 }
 
 func httpStatusCode(ctx context.Context, m api.Module) int32 {
-	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*PluginInstance); ok {
+	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
 		return int32(plugin.LastStatusCode)
 	}
 
@@ -597,7 +597,7 @@ func httpStatusCode(ctx context.Context, m api.Module) int32 {
 }
 
 func httpHeaders(ctx context.Context, _ api.Module) uint64 {
-	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*PluginInstance); ok {
+	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
 		if plugin.LastResponseHeaders == nil {
 			return 0
 		}
@@ -617,7 +617,7 @@ func httpHeaders(ctx context.Context, _ api.Module) uint64 {
 }
 
 func getLogLevel(ctx context.Context, m api.Module) int32 {
-	// if _, ok := ctx.Value(PluginCtxKey("plugin")).(*PluginInstance); ok {
+	// if _, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
 	// 	panic("Invalid context, `plugin` key not found")
 	// }
 	return LogLevel(pluginLogLevel.Load()).ExtismCompat()

--- a/host.go
+++ b/host.go
@@ -102,10 +102,10 @@ func NewHostFunctionWithStack(
 }
 
 type CurrentPlugin struct {
-	plugin *InstantiatedPlugin
+	plugin *Plugin
 }
 
-func (p *InstantiatedPlugin) currentPlugin() *CurrentPlugin {
+func (p *Plugin) currentPlugin() *CurrentPlugin {
 	return &CurrentPlugin{p}
 }
 
@@ -238,7 +238,7 @@ func defineCustomHostFunctions(builder wazero.HostModuleBuilder, funcs []HostFun
 		closure := f.stackCallback
 
 		builder.NewFunctionBuilder().WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
-			if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
+			if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*Plugin); ok {
 				closure(ctx, &CurrentPlugin{plugin}, stack)
 				return
 			}
@@ -320,7 +320,7 @@ func instantiateEnvModule(ctx context.Context, rt wazero.Runtime) (api.Module, e
 
 	logFunc := func(name string, level LogLevel) {
 		hostFunc(name, func(ctx context.Context, m api.Module, offset uint64) {
-			if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
+			if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*Plugin); ok {
 				if LogLevel(pluginLogLevel.Load()) > level {
 					plugin.currentPlugin().Free(offset)
 					return
@@ -352,7 +352,7 @@ func instantiateEnvModule(ctx context.Context, rt wazero.Runtime) (api.Module, e
 }
 
 func store_u64(ctx context.Context, mod api.Module, stack []uint64) {
-	p, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin)
+	p, ok := ctx.Value(PluginCtxKey("plugin")).(*Plugin)
 	if !ok {
 		panic("Invalid context")
 	}
@@ -366,7 +366,7 @@ func store_u64(ctx context.Context, mod api.Module, stack []uint64) {
 }
 
 func load_u64(ctx context.Context, mod api.Module, stack []uint64) {
-	p, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin)
+	p, ok := ctx.Value(PluginCtxKey("plugin")).(*Plugin)
 	if !ok {
 		panic("Invalid context")
 	}
@@ -378,7 +378,7 @@ func load_u64(ctx context.Context, mod api.Module, stack []uint64) {
 }
 
 func inputLoad_u64(ctx context.Context, mod api.Module, stack []uint64) {
-	p, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin)
+	p, ok := ctx.Value(PluginCtxKey("plugin")).(*Plugin)
 	if !ok {
 		panic("Invalid context")
 	}
@@ -395,7 +395,7 @@ func inputLoad_u64(ctx context.Context, mod api.Module, stack []uint64) {
 }
 
 func configGet(ctx context.Context, m api.Module, offset uint64) uint64 {
-	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
+	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*Plugin); ok {
 		cp := plugin.currentPlugin()
 
 		name, err := cp.ReadString(offset)
@@ -421,7 +421,7 @@ func configGet(ctx context.Context, m api.Module, offset uint64) uint64 {
 }
 
 func varGet(ctx context.Context, m api.Module, offset uint64) uint64 {
-	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
+	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*Plugin); ok {
 		cp := plugin.currentPlugin()
 
 		name, err := cp.ReadString(offset)
@@ -449,7 +449,7 @@ func varGet(ctx context.Context, m api.Module, offset uint64) uint64 {
 }
 
 func varSet(ctx context.Context, m api.Module, nameOffset uint64, valueOffset uint64) {
-	plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin)
+	plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*Plugin)
 	if !ok {
 		panic("Invalid context, `plugin` key not found")
 	}
@@ -496,7 +496,7 @@ func varSet(ctx context.Context, m api.Module, nameOffset uint64, valueOffset ui
 }
 
 func httpRequest(ctx context.Context, m api.Module, requestOffset uint64, bodyOffset uint64) uint64 {
-	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
+	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*Plugin); ok {
 		cp := plugin.currentPlugin()
 
 		if plugin.LastResponseHeaders != nil {
@@ -600,7 +600,7 @@ func httpRequest(ctx context.Context, m api.Module, requestOffset uint64, bodyOf
 }
 
 func httpStatusCode(ctx context.Context, m api.Module) int32 {
-	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
+	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*Plugin); ok {
 		return int32(plugin.LastStatusCode)
 	}
 
@@ -608,7 +608,7 @@ func httpStatusCode(ctx context.Context, m api.Module) int32 {
 }
 
 func httpHeaders(ctx context.Context, _ api.Module) uint64 {
-	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
+	if plugin, ok := ctx.Value(PluginCtxKey("plugin")).(*Plugin); ok {
 		if plugin.LastResponseHeaders == nil {
 			return 0
 		}
@@ -628,7 +628,7 @@ func httpHeaders(ctx context.Context, _ api.Module) uint64 {
 }
 
 func getLogLevel(ctx context.Context, m api.Module) int32 {
-	// if _, ok := callCtx.Value(PluginCtxKey("plugin")).(*InstantiatedPlugin); ok {
+	// if _, ok := callCtx.Value(PluginCtxKey("plugin")).(*Plugin); ok {
 	// 	panic("Invalid context, `plugin` key not found")
 	// }
 	return LogLevel(pluginLogLevel.Load()).ExtismCompat()

--- a/plugin.go
+++ b/plugin.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-type Plugin struct {
+type CompiledPlugin struct {
 	runtime wazero.Runtime
 	extism  api.Module
 	env     wazero.CompiledModule
@@ -42,11 +42,11 @@ type PluginConfig struct {
 	EnableHttpResponseHeaders bool
 }
 
-func NewPlugin(
+func NewCompiledPlugin(
 	ctx context.Context,
 	manifest Manifest,
 	config PluginConfig,
-) (*Plugin, error) {
+) (*CompiledPlugin, error) {
 	count := len(manifest.Wasm)
 	if count == 0 {
 		return nil, fmt.Errorf("manifest can't be empty")
@@ -70,7 +70,7 @@ func NewPlugin(
 		}
 	}
 
-	p := Plugin{
+	p := CompiledPlugin{
 		manifest:       manifest,
 		runtime:        wazero.NewRuntimeWithConfig(ctx, cfg),
 		observeAdapter: config.ObserveAdapter,
@@ -162,11 +162,11 @@ func NewPlugin(
 	return &p, nil
 }
 
-func (p *Plugin) Close(ctx context.Context) error {
+func (p *CompiledPlugin) Close(ctx context.Context) error {
 	return p.runtime.Close(ctx)
 }
 
-func (p *Plugin) Instance(ctx context.Context, config PluginInstanceConfig) (*PluginInstance, error) {
+func (p *CompiledPlugin) Instance(ctx context.Context, config PluginInstanceConfig) (*InstantiatedPlugin, error) {
 	var closers []func(ctx context.Context) error
 
 	// Instantiate the env module which was already pre-compiled as anonymous modules
@@ -241,8 +241,7 @@ func (p *Plugin) Instance(ctx context.Context, config PluginInstanceConfig) (*Pl
 	if p.enableHttpResponseHeaders {
 		headers = map[string]string{}
 	}
-
-	instance := &PluginInstance{
+	instance := &InstantiatedPlugin{
 		close:                closers,
 		extism:               p.extism,
 		hasWasi:              p.hasWasi,

--- a/plugin.go
+++ b/plugin.go
@@ -1,0 +1,241 @@
+package extism
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	observe "github.com/dylibso/observe-sdk/go"
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	"os"
+	"time"
+)
+
+type Plugin struct {
+	runtime        wazero.Runtime
+	extism         api.Module
+	env            wazero.CompiledModule
+	main           wazero.CompiledModule
+	hasWasi        bool
+	manifest       Manifest
+	observeAdapter *observe.AdapterBase
+
+	maxHttp                   int64
+	maxVar                    int64
+	enableHttpResponseHeaders bool
+	LastResponseHeaders       map[string]string
+}
+
+type PluginConfig struct {
+	RuntimeConfig             wazero.RuntimeConfig
+	EnableWasi                bool
+	ObserveAdapter            *observe.AdapterBase
+	ObserveOptions            *observe.Options
+	HostFunctions             []HostFunction
+	EnableHttpResponseHeaders bool
+}
+
+func NewPlugin(
+	ctx context.Context,
+	manifest Manifest,
+	config PluginConfig,
+) (*Plugin, error) {
+	count := len(manifest.Wasm)
+	if count == 0 {
+		return nil, fmt.Errorf("manifest can't be empty")
+	}
+
+	var cfg wazero.RuntimeConfig
+	if config.RuntimeConfig == nil {
+		cfg = wazero.NewRuntimeConfig()
+	} else {
+		cfg = config.RuntimeConfig
+	}
+
+	// Make sure function calls are cancelled if the context is cancelled
+	if manifest.Timeout > 0 {
+		cfg = cfg.WithCloseOnContextDone(true)
+	}
+
+	if manifest.Memory != nil {
+		if manifest.Memory.MaxPages > 0 {
+			cfg = cfg.WithMemoryLimitPages(manifest.Memory.MaxPages)
+		}
+	}
+
+	p := Plugin{
+		runtime:        wazero.NewRuntimeWithConfig(ctx, cfg),
+		observeAdapter: config.ObserveAdapter,
+		manifest:       manifest,
+	}
+
+	var err error
+	p.extism, err = p.runtime.InstantiateWithConfig(ctx, extismRuntimeWasm, wazero.NewModuleConfig().WithName("extism"))
+	if err != nil {
+		return nil, err
+	}
+
+	if config.EnableWasi {
+		wasi_snapshot_preview1.MustInstantiate(ctx, p.runtime)
+		p.hasWasi = true
+	}
+
+	p.env, err = buildEnvModule(ctx, p.runtime, p.extism)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build host modules
+	hostModules := make(map[string][]HostFunction)
+	for _, f := range config.HostFunctions {
+		hostModules[f.Namespace] = append(hostModules[f.Namespace], f)
+	}
+	for name, funcs := range hostModules {
+		_, err := buildHostModule(ctx, p.runtime, name, funcs)
+		if err != nil {
+			return nil, fmt.Errorf("building host module: %w", err)
+		}
+	}
+
+	// Try to find the main module:
+	//  - There is always one main module
+	//  - If a Wasm value has the Name field set to "main" then use that module
+	//  - If there is only one module in the manifest then that is the main module by default
+	//  - Otherwise the last module listed is the main module
+
+	var trace *observe.TraceCtx
+	modules := map[string]wazero.CompiledModule{}
+	for i, wasm := range manifest.Wasm {
+		data, err := wasm.ToWasmData(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		_, mainExists := modules["main"]
+		if data.Name == "" || i == len(manifest.Wasm)-1 && !mainExists {
+			data.Name = "main"
+		}
+
+		if data.Name == "main" && config.ObserveAdapter != nil {
+			trace, err = config.ObserveAdapter.NewTraceCtx(ctx, p.runtime, data.Data, config.ObserveOptions)
+			if err != nil {
+				return nil, fmt.Errorf("failed to initialize Observe Adapter: %v", err)
+			}
+
+			trace.Finish()
+		}
+
+		_, okm := modules[data.Name]
+
+		if data.Name == "extism:host/env" || okm {
+			return nil, fmt.Errorf("module name collision: '%s'", data.Name)
+		}
+
+		if data.Hash != "" {
+			calculatedHash := calculateHash(data.Data)
+			if data.Hash != calculatedHash {
+				return nil, fmt.Errorf("hash mismatch for module '%s'", data.Name)
+			}
+		}
+
+		m, err := p.runtime.CompileModule(ctx, data.Data)
+		if err != nil {
+			return nil, err
+		}
+		modules[data.Name] = m
+
+		if data.Name == "main" {
+			p.main, err = p.runtime.CompileModule(ctx, data.Data)
+			if err != nil {
+				return nil, fmt.Errorf("failed to compile main module: %v", err)
+			}
+		}
+	}
+
+	if p.main == nil {
+		return nil, errors.New("no main module found")
+	}
+
+	return &p, nil
+}
+
+func (p *Plugin) Instance(ctx context.Context, config PluginInstanceConfig) (*PluginInstance, error) {
+	var closers []func(ctx context.Context) error
+
+	// Instantiate the env module which was already pre-compiled as anonymous modules
+	// allowing them to be dynamically imported by the import resolver. We'll clean up
+	// the env module when the plugin instance is closed.
+	env, err := p.runtime.InstantiateModule(ctx, p.env, wazero.NewModuleConfig().WithName(""))
+	if err != nil {
+		return nil, fmt.Errorf("instantiating env module: %w", err)
+	}
+	closers = append(closers, env.Close)
+	ctx = experimental.WithImportResolver(ctx, func(lookupName string) api.Module {
+		if lookupName == "extism:host/env" {
+			return env
+		}
+		return nil
+	})
+
+	moduleConfig := config.ModuleConfig
+	if moduleConfig == nil {
+		moduleConfig = wazero.NewModuleConfig()
+	}
+
+	// NOTE: this is only necessary for guest modules because
+	// host modules have the same access privileges as the host itself
+	fs := wazero.NewFSConfig()
+
+	// NOTE: we don't want wazero to call the start function, we will initialize
+	// the guest runtime manually.
+	// See: https://github.com/extism/go-sdk/pull/1#issuecomment-1650527495
+	moduleConfig = moduleConfig.WithStartFunctions().WithFSConfig(fs)
+
+	_, wasiOutput := os.LookupEnv("EXTISM_ENABLE_WASI_OUTPUT")
+	if p.hasWasi && wasiOutput {
+		moduleConfig = moduleConfig.WithStderr(os.Stderr).WithStdout(os.Stdout)
+	}
+
+	main, err := p.runtime.InstantiateModule(ctx, p.main, moduleConfig)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating module: %w", err)
+	}
+	closers = append(closers, main.Close)
+
+	p.maxHttp = int64(1024 * 1024 * 50)
+	if p.manifest.Memory != nil && p.manifest.Memory.MaxHttpResponseBytes >= 0 {
+		p.maxHttp = p.manifest.Memory.MaxHttpResponseBytes
+	}
+
+	p.maxVar = int64(1024 * 1024)
+	if p.manifest.Memory != nil && p.manifest.Memory.MaxVarBytes >= 0 {
+		p.maxVar = p.manifest.Memory.MaxVarBytes
+	}
+
+	var headers map[string]string = nil
+	if p.enableHttpResponseHeaders {
+		headers = map[string]string{}
+	}
+
+	instance := &PluginInstance{
+		close:                closers,
+		plugin:               p,
+		module:               main,
+		Timeout:              time.Duration(p.manifest.Timeout) * time.Millisecond,
+		Config:               p.manifest.Config,
+		Var:                  make(map[string][]byte),
+		AllowedHosts:         p.manifest.AllowedHosts,
+		AllowedPaths:         p.manifest.AllowedPaths,
+		LastStatusCode:       0,
+		LastResponseHeaders:  headers,
+		MaxHttpResponseBytes: p.maxHttp,
+		MaxVarBytes:          p.maxVar,
+		guestRuntime:         guestRuntime{},
+		Adapter:              p.observeAdapter,
+		log:                  logStd,
+	}
+	instance.guestRuntime = detectGuestRuntime(ctx, instance)
+	return instance, nil
+}

--- a/plugin.go
+++ b/plugin.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	observe "github.com/dylibso/observe-sdk/go"
 	"github.com/tetratelabs/wazero"
-	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/experimental"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	"os"
 	"strings"
@@ -16,8 +14,6 @@ import (
 
 type CompiledPlugin struct {
 	runtime wazero.Runtime
-	extism  api.Module
-	env     wazero.CompiledModule
 	main    wazero.CompiledModule
 	// this is the raw wasm bytes of the provided module, it is required when using a tracing observeAdapter.
 	// If an adapter is not provided, this field will be nil.
@@ -77,20 +73,9 @@ func NewCompiledPlugin(
 		observeOptions: config.ObserveOptions,
 	}
 
-	var err error
-	p.extism, err = p.runtime.InstantiateWithConfig(ctx, extismRuntimeWasm, wazero.NewModuleConfig().WithName("extism"))
-	if err != nil {
-		return nil, err
-	}
-
 	if config.EnableWasi {
 		wasi_snapshot_preview1.MustInstantiate(ctx, p.runtime)
 		p.hasWasi = true
-	}
-
-	p.env, err = buildEnvModule(ctx, p.runtime, p.extism)
-	if err != nil {
-		return nil, err
 	}
 
 	// Build host modules
@@ -169,21 +154,6 @@ func (p *CompiledPlugin) Close(ctx context.Context) error {
 func (p *CompiledPlugin) Instance(ctx context.Context, config PluginInstanceConfig) (*InstantiatedPlugin, error) {
 	var closers []func(ctx context.Context) error
 
-	// Instantiate the env module which was already pre-compiled as anonymous modules
-	// allowing them to be dynamically imported by the import resolver. We'll clean up
-	// the env module when the plugin instance is closed.
-	env, err := p.runtime.InstantiateModule(ctx, p.env, wazero.NewModuleConfig().WithName(""))
-	if err != nil {
-		return nil, fmt.Errorf("instantiating env module: %w", err)
-	}
-	closers = append(closers, env.Close)
-	ctx = experimental.WithImportResolver(ctx, func(lookupName string) api.Module {
-		if lookupName == "extism:host/env" {
-			return env
-		}
-		return nil
-	})
-
 	moduleConfig := config.ModuleConfig
 	if moduleConfig == nil {
 		moduleConfig = wazero.NewModuleConfig()
@@ -212,6 +182,7 @@ func (p *CompiledPlugin) Instance(ctx context.Context, config PluginInstanceConf
 	}
 
 	var trace *observe.TraceCtx
+	var err error
 	if p.observeAdapter != nil {
 		trace, err = p.observeAdapter.NewTraceCtx(ctx, p.runtime, p.wasmBytes, p.observeOptions)
 		if err != nil {
@@ -220,6 +191,18 @@ func (p *CompiledPlugin) Instance(ctx context.Context, config PluginInstanceConf
 
 		trace.Finish()
 	}
+
+	extism, err := p.runtime.InstantiateWithConfig(ctx, extismRuntimeWasm, wazero.NewModuleConfig().WithName("extism"))
+	if err != nil {
+		return nil, err
+	}
+	closers = append(closers, extism.Close)
+
+	env, err := buildEnvModule(ctx, p.runtime, extism)
+	if err != nil {
+		return nil, err
+	}
+	closers = append(closers, env.Close)
 
 	main, err := p.runtime.InstantiateModule(ctx, p.main, moduleConfig)
 	if err != nil {
@@ -243,7 +226,7 @@ func (p *CompiledPlugin) Instance(ctx context.Context, config PluginInstanceConf
 	}
 	instance := &InstantiatedPlugin{
 		close:                closers,
-		extism:               p.extism,
+		extism:               extism,
 		hasWasi:              p.hasWasi,
 		module:               main,
 		Timeout:              time.Duration(p.manifest.Timeout) * time.Millisecond,

--- a/runtime.go
+++ b/runtime.go
@@ -21,7 +21,7 @@ type guestRuntime struct {
 	initialized bool
 }
 
-func detectGuestRuntime(ctx context.Context, p *InstantiatedPlugin) guestRuntime {
+func detectGuestRuntime(ctx context.Context, p *Plugin) guestRuntime {
 	runtime, ok := haskellRuntime(ctx, p, p.module)
 	if ok {
 		return runtime
@@ -39,7 +39,7 @@ func detectGuestRuntime(ctx context.Context, p *InstantiatedPlugin) guestRuntime
 // Check for Haskell runtime initialization functions
 // Initialize Haskell runtime if `hs_init` and `hs_exit` are present,
 // by calling the `hs_init` export
-func haskellRuntime(ctx context.Context, p *InstantiatedPlugin, m api.Module) (guestRuntime, bool) {
+func haskellRuntime(ctx context.Context, p *Plugin, m api.Module) (guestRuntime, bool) {
 	initFunc := m.ExportedFunction("hs_init")
 	if initFunc == nil {
 		return guestRuntime{}, false
@@ -73,7 +73,7 @@ func haskellRuntime(ctx context.Context, p *InstantiatedPlugin, m api.Module) (g
 }
 
 // Check for initialization functions defined by the WASI standard
-func wasiRuntime(ctx context.Context, p *InstantiatedPlugin, m api.Module) (guestRuntime, bool) {
+func wasiRuntime(ctx context.Context, p *Plugin, m api.Module) (guestRuntime, bool) {
 	if !p.hasWasi {
 		return guestRuntime{}, false
 	}
@@ -89,7 +89,7 @@ func wasiRuntime(ctx context.Context, p *InstantiatedPlugin, m api.Module) (gues
 }
 
 // Check for `_initialize` this is used by WASI to initialize certain interfaces.
-func reactorModule(ctx context.Context, m api.Module, p *InstantiatedPlugin) (guestRuntime, bool) {
+func reactorModule(ctx context.Context, m api.Module, p *Plugin) (guestRuntime, bool) {
 	init := findFunc(ctx, m, p, "_initialize")
 	if init == nil {
 		return guestRuntime{}, false
@@ -103,7 +103,7 @@ func reactorModule(ctx context.Context, m api.Module, p *InstantiatedPlugin) (gu
 
 // Check for `__wasm__call_ctors`, this is used by WASI to
 // initialize certain interfaces.
-func commandModule(ctx context.Context, m api.Module, p *InstantiatedPlugin) (guestRuntime, bool) {
+func commandModule(ctx context.Context, m api.Module, p *Plugin) (guestRuntime, bool) {
 	init := findFunc(ctx, m, p, "__wasm_call_ctors")
 	if init == nil {
 		return guestRuntime{}, false
@@ -115,7 +115,7 @@ func commandModule(ctx context.Context, m api.Module, p *InstantiatedPlugin) (gu
 	return guestRuntime{runtimeType: Wasi, init: init}, true
 }
 
-func findFunc(ctx context.Context, m api.Module, p *InstantiatedPlugin, name string) func(context.Context) error {
+func findFunc(ctx context.Context, m api.Module, p *Plugin, name string) func(context.Context) error {
 	initFunc := m.ExportedFunction(name)
 	if initFunc == nil {
 		return nil

--- a/runtime.go
+++ b/runtime.go
@@ -21,7 +21,7 @@ type guestRuntime struct {
 	initialized bool
 }
 
-func detectGuestRuntime(ctx context.Context, p *PluginInstance) guestRuntime {
+func detectGuestRuntime(ctx context.Context, p *InstantiatedPlugin) guestRuntime {
 	runtime, ok := haskellRuntime(ctx, p, p.module)
 	if ok {
 		return runtime
@@ -39,7 +39,7 @@ func detectGuestRuntime(ctx context.Context, p *PluginInstance) guestRuntime {
 // Check for Haskell runtime initialization functions
 // Initialize Haskell runtime if `hs_init` and `hs_exit` are present,
 // by calling the `hs_init` export
-func haskellRuntime(ctx context.Context, p *PluginInstance, m api.Module) (guestRuntime, bool) {
+func haskellRuntime(ctx context.Context, p *InstantiatedPlugin, m api.Module) (guestRuntime, bool) {
 	initFunc := m.ExportedFunction("hs_init")
 	if initFunc == nil {
 		return guestRuntime{}, false
@@ -73,7 +73,7 @@ func haskellRuntime(ctx context.Context, p *PluginInstance, m api.Module) (guest
 }
 
 // Check for initialization functions defined by the WASI standard
-func wasiRuntime(ctx context.Context, p *PluginInstance, m api.Module) (guestRuntime, bool) {
+func wasiRuntime(ctx context.Context, p *InstantiatedPlugin, m api.Module) (guestRuntime, bool) {
 	if !p.hasWasi {
 		return guestRuntime{}, false
 	}
@@ -89,7 +89,7 @@ func wasiRuntime(ctx context.Context, p *PluginInstance, m api.Module) (guestRun
 }
 
 // Check for `_initialize` this is used by WASI to initialize certain interfaces.
-func reactorModule(ctx context.Context, m api.Module, p *PluginInstance) (guestRuntime, bool) {
+func reactorModule(ctx context.Context, m api.Module, p *InstantiatedPlugin) (guestRuntime, bool) {
 	init := findFunc(ctx, m, p, "_initialize")
 	if init == nil {
 		return guestRuntime{}, false
@@ -103,7 +103,7 @@ func reactorModule(ctx context.Context, m api.Module, p *PluginInstance) (guestR
 
 // Check for `__wasm__call_ctors`, this is used by WASI to
 // initialize certain interfaces.
-func commandModule(ctx context.Context, m api.Module, p *PluginInstance) (guestRuntime, bool) {
+func commandModule(ctx context.Context, m api.Module, p *InstantiatedPlugin) (guestRuntime, bool) {
 	init := findFunc(ctx, m, p, "__wasm_call_ctors")
 	if init == nil {
 		return guestRuntime{}, false
@@ -115,7 +115,7 @@ func commandModule(ctx context.Context, m api.Module, p *PluginInstance) (guestR
 	return guestRuntime{runtimeType: Wasi, init: init}, true
 }
 
-func findFunc(ctx context.Context, m api.Module, p *PluginInstance, name string) func(context.Context) error {
+func findFunc(ctx context.Context, m api.Module, p *InstantiatedPlugin, name string) func(context.Context) error {
 	initFunc := m.ExportedFunction(name)
 	if initFunc == nil {
 		return nil

--- a/runtime.go
+++ b/runtime.go
@@ -74,7 +74,7 @@ func haskellRuntime(ctx context.Context, p *PluginInstance, m api.Module) (guest
 
 // Check for initialization functions defined by the WASI standard
 func wasiRuntime(ctx context.Context, p *PluginInstance, m api.Module) (guestRuntime, bool) {
-	if !p.plugin.hasWasi {
+	if !p.hasWasi {
 		return guestRuntime{}, false
 	}
 


### PR DESCRIPTION
See [Discord thread](https://discord.com/channels/1011124058408112148/1050087851443888138/1298037616838443029).

It seems like there should be a `Plugin` type that is thread-safe, and a `PluginInstance` type that is not thread-safe. The `Plugin `contains the runtime and the compiled module, and you'd have something like `func(p *Plugin) NewInstance() *PluginInstance` which would instantiate a wazero module that would then be used in a single-threaded context.

The idea here is I can compile my plugin one time, and call functions from the module as many times as I want, concurrently, without having to re-compile.